### PR TITLE
removed "(/src)" from building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
    ```sh
    npm install -g pkg
    ```
-3. In the project folder (/src), run:
+3. In the project folder run:
    ```sh
    npm install
    ```


### PR DESCRIPTION
package.json moved to the root folder and isnt present in /src anymore