### PR TITLE
Fix drop quantity larger than one slot

### DIFF
--- a/cheats.js
+++ b/cheats.js
@@ -2412,9 +2412,10 @@ function setupAutoLootProxy() {
       }
 
       // Move item from inventory into chest if the slot isn't locked.
-      const inventorySlot = inventoryOrder.indexOf(dropType);
-      const lockedSlot = bEngine.getGameAttribute("LockedSlots")[inventorySlot !== -1 ? inventorySlot : 0];
-      if (chestSlot !== -1 && inventorySlot !== -1 && !lockedSlot) {
+      let inventorySlot;
+      while (chestSlot !== -1 &&
+      (inventorySlot = inventoryOrder.indexOf(dropType)) !== -1 &&
+      !bEngine.getGameAttribute("LockedSlots")[inventorySlot !== -1 ? inventorySlot : 0]) {
         chestOrder[chestSlot] = chestOrder[chestSlot] === "Blank" ? context._DropType : chestOrder[chestSlot];
         chestQuantity[chestSlot] += itemQuantity[inventorySlot];
         itemQuantity[inventorySlot] = 0;


### PR DESCRIPTION
Will now put all items in chest if drop quantity is larger than one slot.

Sorry missed this problem when testing but noticed when I hit collect all on my traps so got it fixed.