### PR TITLE
fix: card names in drop command

### DIFF
--- a/src/cheats/api/suggestions.js
+++ b/src/cheats/api/suggestions.js
@@ -70,7 +70,13 @@ export function getAutoCompleteSuggestions() {
     addChoices(choices, itemDefs, (code, item) => {
         if (!item.h.displayName) return null;
         if (itemBlacklist.has(code)) return null;
-        const name = item.h.displayName.replace(/_/g, " ");
+        let name;
+        // get the right message names for the cards
+        if (code.startsWith("Cards")) {
+            name = monsterDefs[item.h.desc_line1]?.h.Name?.replace(/_/g, " ") ?? item.h.desc_line1;
+        } else {
+            name = item.h.displayName.replace(/_/g, " ");
+        }
         // filtering out ui items named strung jewels
         if (code !== "Quest66" && name === "Strung Jewels") return null;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Autocomplete item suggestions now properly display card-type item names with correct naming conventions, improving search accuracy and making it easier to find and reference card items when navigating the search interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->