### PR TITLE
Add bigmodel cheat

### DIFF
--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -4,7 +4,7 @@
  * Account-wide cheats:
  * - gembuylimit, mtx, post, guild, task, quest, star
  * - giant, gems, plunderous, candy, candytime, nodmg
- * - hidenames, noanim, eventitems, autoloot, perfectobols, autoparty
+ * - hidenames, noanim, bigmodel, eventitems, autoloot, perfectobols, autoparty
  * - arcade, eventspins, hoopshop, dartshop, guildpoints, cardcopy
  */
 
@@ -35,6 +35,7 @@ registerCheats({
         { name: "nodmg", message: "no damage numbers" },
         { name: "hidenames", message: "hide player names in world and UI" },
         { name: "noanim", message: "stop all game animations" },
+        { name: "bigmodel", message: "set all player model sizes on spawn", configurable: true },
         { name: "eventitems", message: "unlimited event item drops" },
         { name: "autoloot", message: "autoloot immeditely to chest. Check config for more" },
         { name: "autoparty", message: "Automatically add on screen players to your party" },

--- a/src/cheats/proxies/events020.js
+++ b/src/cheats/proxies/events020.js
@@ -1,0 +1,72 @@
+/**
+ * Events 020 Proxies
+ *
+ * Proxies for ActorEvents_20 (player actor init):
+ * - Big model scale override for all players
+ */
+
+import { cheatState, cheatConfig } from "../core/state.js";
+import { events } from "../core/globals.js";
+
+const DEFAULT_SIZE = 300;
+
+/**
+ * Setup player model size proxy.
+ *
+ * NOTE: Intentionally deviates from "base first" pattern.
+ * We override actor.growTo during ActorEvents_20.init to force size globally.
+ */
+export function setupEvents020Proxies() {
+    const actorEvents20 = events(20);
+    if (!actorEvents20?.prototype?.init) return;
+
+    if (actorEvents20.prototype._bigModelPatched) return;
+    Object.defineProperty(actorEvents20.prototype, "_bigModelPatched", { value: true, enumerable: false });
+
+    const originalInit = actorEvents20.prototype.init;
+    actorEvents20.prototype.init = function (...args) {
+        if (!cheatState.wide?.bigmodel) {
+            return Reflect.apply(originalInit, this, args);
+        }
+
+        const actor = this.actor;
+        const originalGrowTo = actor?.growTo;
+        const canPatchGrowTo = typeof originalGrowTo === "function";
+
+        if (!canPatchGrowTo) {
+            return Reflect.apply(originalInit, this, args);
+        }
+
+        const targetSize = resolveBigModelSize();
+        const targetScale = targetSize / 100;
+        let growToOverridden = false;
+        try {
+            actor.growTo = function (...growArgs) {
+                const patchedArgs = [targetScale, targetScale, ...growArgs.slice(2)];
+                return Reflect.apply(originalGrowTo, this, patchedArgs);
+            };
+            growToOverridden = true;
+
+            const base = Reflect.apply(originalInit, this, args);
+            this._PlayerSize = targetSize;
+            return base;
+        } finally {
+            if (growToOverridden) {
+                actor.growTo = originalGrowTo;
+            }
+        }
+    };
+}
+
+/**
+ * Resolve the configured big model size with a safe fallback.
+ *
+ * @returns {number} Target player size.
+ */
+function resolveBigModelSize() {
+    const configuredSize = cheatConfig?.wide?.bigmodel;
+    if (typeof configuredSize === "number" && Number.isFinite(configuredSize) && configuredSize > 0) {
+        return configuredSize;
+    }
+    return DEFAULT_SIZE;
+}

--- a/src/cheats/proxies/setup.js
+++ b/src/cheats/proxies/setup.js
@@ -11,6 +11,7 @@ import { setupFirebaseProxy, setupFirebaseStorageProxy, setupSteamAchievementPro
 import { setupGameAttributeProxies } from "./gameAttributes.js";
 import { setupCListProxy } from "./clist.js";
 import { setupEvents012Proxies } from "./events012.js";
+import { setupEvents020Proxies } from "./events020.js";
 import { setupItemGetNotificationProxy } from "./events034.js";
 import { setupEvents038Proxies } from "./events038.js";
 import { setupAutoLootProxy } from "./events044.js";
@@ -50,6 +51,7 @@ export function setupAllProxies() {
 
     // ActorEvents proxies by event number
     setupEvents012Proxies();
+    setupEvents020Proxies();
     setupAutoLootProxy();
     setupItemGetNotificationProxy();
     setupEvents038Proxies();


### PR DESCRIPTION
This pull request introduces a new configurable "big model" cheat that allows all player models to be globally resized on spawn. The implementation adds a new cheat option, integrates it into the cheat registration and configuration system, and wires up the necessary proxy logic to override player model scaling during initialization.

**New "Big Model" Cheat Feature:**

* Added a new `bigmodel` cheat to the account-wide cheats list in `wide.js`, making it configurable and available alongside other global cheats. [[1]](diffhunk://#diff-df5cdfe7aa672595ec51f0a3dc1ac58b2ea5a624aa62f15062a9392d64d8ead9L7-R7) [[2]](diffhunk://#diff-df5cdfe7aa672595ec51f0a3dc1ac58b2ea5a624aa62f15062a9392d64d8ead9R38)
* Registered the `bigmodel` cheat with a description and marked it as configurable in the cheat registration array in `wide.js`.

**Implementation of Model Scaling Logic:**

* Introduced `events020.js` proxy module, which hooks into player actor initialization (`ActorEvents_20.init`) to override the `growTo` method and set all player model sizes based on the configured value or a default.
* Added `setupEvents020Proxies` to the proxy setup sequence in `setup.js`, ensuring the new proxy is initialized with all other event proxies. [[1]](diffhunk://#diff-7ce7e8deec8c5ac2c3bf5343c829b914e39a6d02569b148dedccca34693be20cR14) [[2]](diffhunk://#diff-7ce7e8deec8c5ac2c3bf5343c829b914e39a6d02569b148dedccca34693be20cR54)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a toggleable "bigmodel" cheat that allows customization of all player model sizes on spawn. This feature is fully configurable for user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->