### PR TITLE
bigmodel cheat

### DIFF
--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -4,7 +4,7 @@
  * Account-wide cheats:
  * - gembuylimit, mtx, post, guild, task, quest, star
  * - giant, gems, plunderous, candy, candytime, nodmg
- * - hidenames, noanim, eventitems, autoloot, perfectobols, autoparty
+ * - hidenames, noanim, bigmodel, eventitems, autoloot, perfectobols, autoparty
  * - arcade, eventspins, hoopshop, dartshop, guildpoints, cardcopy
  */
 
@@ -35,6 +35,7 @@ registerCheats({
         { name: "nodmg", message: "no damage numbers" },
         { name: "hidenames", message: "hide player names in world and UI" },
         { name: "noanim", message: "stop all game animations" },
+        { name: "bigmodel", message: "set all player model sizes on spawn", configurable: true },
         { name: "eventitems", message: "unlimited event item drops" },
         { name: "autoloot", message: "autoloot immeditely to chest. Check config for more" },
         { name: "autoparty", message: "Automatically add on screen players to your party" },

--- a/src/cheats/proxies/events020.js
+++ b/src/cheats/proxies/events020.js
@@ -8,65 +8,37 @@
 import { cheatState, cheatConfig } from "../core/state.js";
 import { events } from "../core/globals.js";
 
-const DEFAULT_SIZE = 300;
-
 /**
  * Setup player model size proxy.
  *
- * NOTE: Intentionally deviates from "base first" pattern.
- * We override actor.growTo during ActorEvents_20.init to force size globally.
+ * Override actor.growTo during ActorEvents_20.init to force size globally.
  */
 export function setupEvents020Proxies() {
     const actorEvents20 = events(20);
-    if (!actorEvents20?.prototype?.init) return;
-
-    if (actorEvents20.prototype._bigModelPatched) return;
-    Object.defineProperty(actorEvents20.prototype, "_bigModelPatched", { value: true, enumerable: false });
 
     const originalInit = actorEvents20.prototype.init;
     actorEvents20.prototype.init = function (...args) {
-        if (!cheatState.wide?.bigmodel) {
+        if (!cheatState.wide.bigmodel) {
             return Reflect.apply(originalInit, this, args);
         }
 
         const actor = this.actor;
-        const originalGrowTo = actor?.growTo;
-        const canPatchGrowTo = typeof originalGrowTo === "function";
+        const originalGrowTo = actor.growTo;
 
-        if (!canPatchGrowTo) {
-            return Reflect.apply(originalInit, this, args);
-        }
-
-        const targetSize = resolveBigModelSize();
+        const targetSize = cheatConfig.wide.bigmodel;
         const targetScale = targetSize / 100;
-        let growToOverridden = false;
-        try {
-            actor.growTo = function (...growArgs) {
-                const patchedArgs = [targetScale, targetScale, ...growArgs.slice(2)];
-                return Reflect.apply(originalGrowTo, this, patchedArgs);
-            };
-            growToOverridden = true;
 
-            const base = Reflect.apply(originalInit, this, args);
-            this._PlayerSize = targetSize;
-            return base;
-        } finally {
-            if (growToOverridden) {
-                actor.growTo = originalGrowTo;
-            }
-        }
+        // Intercept `growTo` before calling the base init instead of modifying scale after.
+        // This prevents characters from being normal size when swapping maps and then growing to the bigger size.
+        actor.growTo = function (...growArgs) {
+            return Reflect.apply(originalGrowTo, this, [targetScale, targetScale, ...growArgs.slice(2)]);
+        };
+
+        const base = Reflect.apply(originalInit, this, args);
+        
+        this._PlayerSize = targetSize;
+        actor.growTo = originalGrowTo;
+        
+        return base;
     };
-}
-
-/**
- * Resolve the configured big model size with a safe fallback.
- *
- * @returns {number} Target player size.
- */
-function resolveBigModelSize() {
-    const configuredSize = cheatConfig?.wide?.bigmodel;
-    if (typeof configuredSize === "number" && Number.isFinite(configuredSize) && configuredSize > 0) {
-        return configuredSize;
-    }
-    return DEFAULT_SIZE;
 }

--- a/src/cheats/proxies/events020.js
+++ b/src/cheats/proxies/events020.js
@@ -1,0 +1,72 @@
+/**
+ * Events 020 Proxies
+ *
+ * Proxies for ActorEvents_20 (player actor init):
+ * - Big model scale override for all players
+ */
+
+import { cheatState, cheatConfig } from "../core/state.js";
+import { events } from "../core/globals.js";
+
+const DEFAULT_SIZE = 300;
+
+/**
+ * Setup player model size proxy.
+ *
+ * NOTE: Intentionally deviates from "base first" pattern.
+ * We override actor.growTo during ActorEvents_20.init to force size globally.
+ */
+export function setupEvents020Proxies() {
+    const actorEvents20 = events(20);
+    if (!actorEvents20?.prototype?.init) return;
+
+    if (actorEvents20.prototype._bigModelPatched) return;
+    Object.defineProperty(actorEvents20.prototype, "_bigModelPatched", { value: true, enumerable: false });
+
+    const originalInit = actorEvents20.prototype.init;
+    actorEvents20.prototype.init = function (...args) {
+        if (!cheatState.wide?.bigmodel) {
+            return Reflect.apply(originalInit, this, args);
+        }
+
+        const actor = this.actor;
+        const originalGrowTo = actor?.growTo;
+        const canPatchGrowTo = typeof originalGrowTo === "function";
+
+        if (!canPatchGrowTo) {
+            return Reflect.apply(originalInit, this, args);
+        }
+
+        const targetSize = resolveBigModelSize();
+        const targetScale = targetSize / 100;
+        let growToOverridden = false;
+        try {
+            actor.growTo = function (...growArgs) {
+                const patchedArgs = [targetScale, targetScale, ...growArgs.slice(2)];
+                return Reflect.apply(originalGrowTo, this, patchedArgs);
+            };
+            growToOverridden = true;
+
+            const base = Reflect.apply(originalInit, this, args);
+            this._PlayerSize = targetSize;
+            return base;
+        } finally {
+            if (growToOverridden) {
+                actor.growTo = originalGrowTo;
+            }
+        }
+    };
+}
+
+/**
+ * Resolve the configured big model size with a safe fallback.
+ *
+ * @returns {number} Target player size.
+ */
+function resolveBigModelSize() {
+    const configuredSize = cheatConfig?.wide?.bigmodel;
+    if (typeof configuredSize === "number" && Number.isFinite(configuredSize) && configuredSize > 0) {
+        return configuredSize;
+    }
+    return DEFAULT_SIZE;
+}

--- a/src/cheats/proxies/setup.js
+++ b/src/cheats/proxies/setup.js
@@ -11,6 +11,7 @@ import { setupFirebaseProxy, setupFirebaseStorageProxy, setupSteamAchievementPro
 import { setupGameAttributeProxies } from "./gameAttributes.js";
 import { setupCListProxy } from "./clist.js";
 import { setupEvents012Proxies } from "./events012.js";
+import { setupEvents020Proxies } from "./events020.js";
 import { setupItemGetNotificationProxy } from "./events034.js";
 import { setupEvents038Proxies } from "./events038.js";
 import { setupAutoLootProxy } from "./events044.js";
@@ -50,6 +51,7 @@ export function setupAllProxies() {
 
     // ActorEvents proxies by event number
     setupEvents012Proxies();
+    setupEvents020Proxies();
     setupAutoLootProxy();
     setupItemGetNotificationProxy();
     setupEvents038Proxies();


### PR DESCRIPTION
Added bigmodel cheat to scale all players on the map to a certain size.
Size has no limit since the game handles all the 'proper' sizes (tested 10k but at this size only the pixels of the feet are visible and at 10 the character is only 2-4 pixels).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bigmodel` cheat: A new configurable account-wide cheat that allows players to adjust their character model size at spawn time. The feature provides uniform scaling control with percentage-based configuration options. It integrates seamlessly with the existing cheat system and is available for immediate use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->