### PR TITLE
minigame fishing rework

### DIFF
--- a/config.js
+++ b/config.js
@@ -778,6 +778,11 @@ exports.cheatConfig = {
             // Grid_CanWeSelect: (t) => t,
         },
     },
+    minigame: {
+        fishing: {
+            skipWhale: true, // turn on/off for megalodon farming
+        },
+    },
 };
 
 exports.injectorConfig = {

--- a/src/cheats/cheats/minigame.js
+++ b/src/cheats/cheats/minigame.js
@@ -17,7 +17,7 @@ registerCheats({
     message: "unlimited minigames",
     subcheats: [
         { name: "mining", message: "mining minigame cheat" },
-        { name: "fishing", message: "fishing minigame cheat" },
+        { name: "fishing", message: "fish aimbot" },
         { name: "catching", message: "catching minigame cheat" },
         { name: "choppin", message: "choppin minigame cheat" },
         { name: "poing", message: "poing minigame cheat" },

--- a/src/cheats/cheats/minigame.js
+++ b/src/cheats/cheats/minigame.js
@@ -17,7 +17,7 @@ registerCheats({
     message: "unlimited minigames",
     subcheats: [
         { name: "mining", message: "mining minigame cheat" },
-        { name: "fishing", message: "fish aimbot" },
+        { name: "fishing", message: "fish aimbot", configurable: true },
         { name: "catching", message: "catching minigame cheat" },
         { name: "choppin", message: "choppin minigame cheat" },
         { name: "poing", message: "poing minigame cheat" },

--- a/src/cheats/cheats/minigame.js
+++ b/src/cheats/cheats/minigame.js
@@ -17,7 +17,7 @@ registerCheats({
     message: "unlimited minigames",
     subcheats: [
         { name: "mining", message: "mining minigame cheat" },
-        { name: "fishing", message: "fish aimbot", configurable: true },
+        { name: "fishing", message: "fish aimbot" },
         { name: "catching", message: "catching minigame cheat" },
         { name: "choppin", message: "choppin minigame cheat" },
         { name: "poing", message: "poing minigame cheat" },

--- a/src/cheats/proxies/minigames.js
+++ b/src/cheats/proxies/minigames.js
@@ -20,9 +20,26 @@
  * - Gold Pot Rush (ActorEvents_670) - Instant finish minigame
  */
 
-import { cheatState } from "../core/state.js";
+import { cheatState, cheatConfig } from "../core/state.js";
 import { behavior, events, gga } from "../core/globals.js";
 import { createMethodProxy } from "../utils/proxy.js";
+
+// Find the highest-tier active fish, skipping bombs (type 5) and optionally whales (type 6)
+function findBestFish(genInfo) {
+    const fishes = genInfo[4];
+    let bestIndex = -1;
+    let bestType = -1;
+    for (let i = 0; i < fishes.length; i++) {
+        const f = fishes[i];
+        if (f[0] < 500 && f[1] !== 5
+            && !(cheatConfig.minigame.fishing.skipWhale && f[1] === 6)
+            && f[1] > bestType) {
+            bestType = f[1];
+            bestIndex = i;
+        }
+    }
+    return bestIndex;
+}
 
 // mining, fishing, catching
 function setupEvents229Minigames() {
@@ -35,23 +52,62 @@ function setupEvents229Minigames() {
         return Reflect.apply(originalMining, this, args);
     };
 
-    // fishing block game over
-    const originalFishing = ActorEvents229.prototype._customEvent_FishingGameOver;
-    ActorEvents229.prototype._customEvent_FishingGameOver = function (...args) {
-        if (cheatState.minigame.fishing) return; // Skip original entirely
-        return Reflect.apply(originalFishing, this, args);
-    };
-
-    // catching proxy _GenInfo array for static positions
+    // catching and fishing proxy _GenInfo array
     createMethodProxy(ActorEvents229.prototype, "init", function (base) {
         this._GenInfo = new Proxy(this._GenInfo, {
             get(target, prop, receiver) {
                 if (typeof prop === "symbol") return Reflect.get(target, prop, receiver);
 
                 const index = Number(prop);
+
                 if (cheatState.minigame.catching) {
                     if (index === 31) return 70;
                     if (index === 33) return [95, 95, 95, 95, 95];
+                }
+
+                if (cheatState.minigame.fishing) {
+                    if (index === 4) {
+                        const fishes = Reflect.get(target, prop, receiver);
+                        const bobber = target[8];
+                        const bestIndex = findBestFish(target);
+
+                        if (bestIndex !== -1) {
+                            const bobberX = bobber[0];
+                            return new Proxy(fishes, {
+                                get(fTarget, fProp) {
+                                    if (String(fProp) === String(bestIndex)) {
+                                        return new Proxy(fTarget[fProp], {
+                                            get(fishTarget, fishProp) {
+                                                if (String(fishProp) === "0") {
+                                                    // game marks fish as dead by setting X >= 500; respect that or it loops catches forever
+                                                    if (fishTarget[0] >= 500) return fishTarget[0];
+                                                    return bobberX;
+                                                }
+                                                return Reflect.get(fishTarget, fishProp);
+                                            }
+                                        });
+                                    }
+                                    return Reflect.get(fTarget, fProp);
+                                }
+                            });
+                        }
+                        return fishes;
+                    }
+
+                    // fish swim offset (GenInfo[13]) shifts the visual position; zero it so our faked base X actually aligns
+                    if (index === 13) {
+                        const sines = Reflect.get(target, prop, receiver);
+                        const bestIndex = findBestFish(target);
+                        if (bestIndex !== -1) {
+                            return new Proxy(sines, {
+                                get(sTarget, sProp) {
+                                    if (String(sProp) === String(bestIndex)) return 0;
+                                    return Reflect.get(sTarget, sProp);
+                                }
+                            });
+                        }
+                        return sines;
+                    }
                 }
 
                 return Reflect.get(target, prop, receiver);

--- a/src/cheats/proxies/minigames.js
+++ b/src/cheats/proxies/minigames.js
@@ -7,7 +7,7 @@
  *
  * Supported minigames:
  * - Mining (ActorEvents_229) - Never game over
- * - Fishing (ActorEvents_229) - Never game over
+ * - Fishing (ActorEvents_229) - Fish aimbot
  * - Catching (ActorEvents_229) - Static fly/hoop positions
  * - Choppin (ActorEvents_116) - Gold zone fills bar
  * - Hoops (ActorEvents_510) - Perfect ball/hoop position
@@ -66,47 +66,17 @@ function setupEvents229Minigames() {
                 }
 
                 if (cheatState.minigame.fishing) {
-                    if (index === 4) {
-                        const fishes = Reflect.get(target, prop, receiver);
-                        const bobber = target[8];
-                        const bestIndex = findBestFish(target);
-
-                        if (bestIndex !== -1) {
-                            const bobberX = bobber[0];
-                            return new Proxy(fishes, {
-                                get(fTarget, fProp) {
-                                    if (String(fProp) === String(bestIndex)) {
-                                        return new Proxy(fTarget[fProp], {
-                                            get(fishTarget, fishProp) {
-                                                if (String(fishProp) === "0") {
-                                                    // game marks fish as dead by setting X >= 500; respect that or it loops catches forever
-                                                    if (fishTarget[0] >= 500) return fishTarget[0];
-                                                    return bobberX;
-                                                }
-                                                return Reflect.get(fishTarget, fishProp);
-                                            }
-                                        });
-                                    }
-                                    return Reflect.get(fTarget, fProp);
-                                }
-                            });
-                        }
-                        return fishes;
-                    }
-
-                    // fish swim offset (GenInfo[13]) shifts the visual position; zero it so our faked base X actually aligns
-                    if (index === 13) {
-                        const sines = Reflect.get(target, prop, receiver);
+                    if (index === 4 || index === 13) {
                         const bestIndex = findBestFish(target);
                         if (bestIndex !== -1) {
-                            return new Proxy(sines, {
-                                get(sTarget, sProp) {
-                                    if (String(sProp) === String(bestIndex)) return 0;
-                                    return Reflect.get(sTarget, sProp);
-                                }
-                            });
+                            const fishes = target[4];
+                            const bobber = target[8];
+                            const sines = target[13];
+
+                            fishes[bestIndex][0] = bobber[0];
+                            // fish swim offset shifts visual X; zero it so base X snap stays aligned
+                            sines[bestIndex] = 0;
                         }
-                        return sines;
                     }
                 }
 


### PR DESCRIPTION
- Proxy intercepts _GenInfo[4] to snap rarest active fish to bobber X
- Proxy intercepts _GenInfo[13] to zero sine wave oscillation for targeted fish
- Conditional snap respects fish despawn state (X >= 500)
- Excludes bombs (type 5) and optionally whales (type 6) via cheatConfig
- Added minigame.fishing.skipWhale config option (default: true) for megalodon farming
- Renamed fishing cheat description to 'fish aimbot' _//comment from Lumi: not sure if this is okay or not. i rather have a quick description of the cheat instead of having to guess what "fishing minigame cheat" does/means_

the old minigame fishing cheat wasn't really useful, this should be a good replacement for it ✨
the rarest fish (whale can be skipped through the config) will always snap to the bobbers location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fish aimbot that auto-targets the highest-value fish while avoiding bombs
  * Config option to optionally skip whale targets during fishing
  * Updated fishing cheat label for clearer display

* **Bug Fixes**
  * Restored normal game-over behavior in the fishing minigame for more reliable play
<!-- end of auto-generated comment: release notes by coderabbit.ai -->