### PR TITLE
Fixes for cheat: lvl vials

### DIFF
--- a/src/cheats/cheats/dangerous.js
+++ b/src/cheats/cheats/dangerous.js
@@ -212,7 +212,7 @@ function wipeFunction(params) {
  * @returns {string} Result message
  */
 function alchFn(params) {
-    const setlvl = params[1] || 1000;
+    const setlvl = params[1] ?? 1;
     if (!(params[0] in alchemyTypes)) {
         return `Wrong sub-command, use one of these:\n${Object.keys(alchemyTypes).join(", ")}`;
     }
@@ -226,7 +226,16 @@ function alchFn(params) {
         }
         return `All cauldron rate and cap set to lvl ${setlvl}`;
     }
+    else if(params[0] === "vials") {
+        // There are currently more vials in source code than there are available in game
+        // so we need to use different way of deciding how many iterations we need rather than using Object.keys.
+        // Currently I'm gonna do logic "if vial require item then it's available to unlock" but this might change in future.
+        for (let i = 0; i < cList.AlchemyVialItems.length; i++) tochange[i] = setlvl;
+        return `All vials have changed to lvl ${setlvl}.`;
+    }
+
     for (const index of Object.keys(tochange)) tochange[index] = setlvl;
+
     return `All ${params[0]} levels have changed to ${setlvl}.`;
 }
 


### PR DESCRIPTION
- Fixed problem that requesting anything from alchemyTypes to be set to lvl 0 was setting it to lvl 1000.
- Fixed problem that lvl was set for more vials that there are currently in game causing "ERROR" vials to appear.
- Changed default fallback value to 1 as it's much safer (for example vials can never achieve lvl 1000 in normal game)

Open issue:
https://github.com/MrJoiny/Idleon-Injector/issues/144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new vials alchemy subcommand to expand alchemy cheat functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->