### PR TITLE
feat: add W1 Pets tab to activate pet bonuses via pet-token system

### DIFF
--- a/src/ui/components/Tooltip.js
+++ b/src/ui/components/Tooltip.js
@@ -139,6 +139,7 @@ export const withTooltip = (element, text, position = "top", enabled = true) => 
     });
 
     element.addEventListener("mouseleave", hideTooltip);
+    element.addEventListener("click", hideTooltip);
 
     return element;
 };

--- a/src/ui/components/views/account/W1Tab.js
+++ b/src/ui/components/views/account/W1Tab.js
@@ -9,6 +9,7 @@ import { ForgeTab } from "./w1/ForgeTab.js";
 import { StatuesTab } from "./w1/StatuesTab.js";
 import { OrionTab } from "./w1/OrionTab.js";
 import { StarSignsTab } from "./w1/StarSignsTab.js";
+import { CompanionsTab } from "./w1/CompanionsTab.js";
 import { createComingSoonPlaceholder, renderLazyPanes, renderTabNav } from "./tabShared.js";
 
 const { div } = van.tags;
@@ -20,6 +21,7 @@ const W1_SUBTABS = [
     { id: "statues", label: "STATUES", component: StatuesTab },
     { id: "starsigns", label: "STAR SIGNS", component: StarSignsTab },
     { id: "orion", label: "ORION", component: OrionTab },
+    { id: "companions", label: "PETS", component: CompanionsTab },
 ];
 
 export const W1Tab = () => {

--- a/src/ui/components/views/account/w1/CompanionsTab.js
+++ b/src/ui/components/views/account/w1/CompanionsTab.js
@@ -1,0 +1,295 @@
+/**
+ * W1 - Pets Tab
+ *
+ * Companion definitions come from live game data:
+ *   cList.CompanionDB
+ *   cList.CompanionSetsInfo
+ *   MonsterDefinitionsGET.h[monsterKey].Name
+ *
+ * Selection is the pet-bonus token list in OptionsListAccount[606]: a CSV of
+ * CompanionDB indices. Toggling a pet writes that list live, which activates the
+ * pet's account-wide bonus regardless of how many tokens are actually owned.
+ */
+
+import van from "../../../../vendor/van-1.6.0.js";
+import { gga, readCList, readGgaEntries } from "../../../../services/api.js";
+import { EmptyState } from "../../../EmptyState.js";
+import { SearchBar } from "../../../SearchBar.js";
+import { Icons } from "../../../../assets/icons.js";
+import { withTooltip } from "../../../Tooltip.js";
+import { toIndexedArray } from "../../../../utils/index.js";
+import { RefreshButton } from "../components/AccountPageChrome.js";
+import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
+import { useAccountLoad } from "../accountLoadPolicy.js";
+import { useWriteStatus, writeVerified } from "../accountShared.js";
+
+const { div, button, span, label, input } = van.tags;
+
+const TOKEN_PATH = "OptionsListAccount[606]";
+
+const normalizeSearchText = (value) => String(value ?? "").trim().toLowerCase();
+
+const isUnusedPetText = (value) => {
+    const text = normalizeSearchText(value);
+    return text.includes("not officially in the game") && text.includes("may never be");
+};
+
+const cleanText = (value, fallback = "") => {
+    const text = String(value ?? fallback)
+        .replace(/_/g, " ")
+        .replace(/^\{+\s*/, "")
+        .trim();
+    return text || fallback;
+};
+
+const parseIdList = (value) =>
+    String(value ?? "")
+        .split(",")
+        .map((part) => Number.parseInt(part.trim(), 10))
+        .filter((id) => Number.isFinite(id));
+
+const serializeIds = (idSet) => [...idSet].sort((a, b) => a - b).join(",");
+
+const expandRange = (start, end) => {
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return [];
+    return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+};
+
+const unwrapSingleEntry = (value) => {
+    let current = value;
+    while (true) {
+        const list = toIndexedArray(current);
+        if (list.length !== 1) return current;
+        current = list[0];
+    }
+};
+
+const buildCompanionRows = (rawCompanionDb, rawMonsterDefs) =>
+    toIndexedArray(rawCompanionDb)
+        .map((entry, id) => {
+            const row = toIndexedArray(entry);
+            const monsterKey = row[0];
+            const name = cleanText(rawMonsterDefs?.[monsterKey]?.Name, "");
+            if (!name) return null;
+
+            const effect = cleanText(row[1], "No buff text");
+
+            return { id, monsterKey, name, effect, isUnused: isUnusedPetText(effect) };
+        })
+        .filter(Boolean);
+
+const buildSections = (pets, rawSetsInfo) => {
+    const fallbackIds = pets.map((pet) => pet.id);
+    const validIds = new Set(fallbackIds);
+    const seenIds = new Set();
+    const sections = [];
+    const setsInfo = toIndexedArray(rawSetsInfo);
+
+    const pushSection = (sectionLabel, ids) => {
+        const nextIds = [...new Set(ids)].filter((id) => validIds.has(id) && !seenIds.has(id));
+        if (!nextIds.length) return;
+        nextIds.forEach((id) => seenIds.add(id));
+        sections.push({ label: sectionLabel, ids: nextIds });
+    };
+
+    const primaryGroups = String(unwrapSingleEntry(setsInfo[0]) ?? "")
+        .split("|")
+        .map((group) => parseIdList(group))
+        .filter((group) => group.length > 0);
+
+    primaryGroups.forEach((group, index) => {
+        const ids = group.length >= 2 ? expandRange(group[0], group[1]) : group;
+        pushSection(`SET ${index + 1}`, ids);
+    });
+
+    toIndexedArray(setsInfo[1]).forEach((group, index) => {
+        pushSection(`SPECIAL ${index + 1}`, parseIdList(unwrapSingleEntry(group)));
+    });
+
+    toIndexedArray(setsInfo[2]).forEach((group, index) => {
+        pushSection(`EXTRA ${index + 1}`, parseIdList(unwrapSingleEntry(group)));
+    });
+
+    const leftoverIds = fallbackIds.filter((id) => !seenIds.has(id));
+    if (leftoverIds.length) pushSection(sections.length ? "OTHER" : "ALL PETS", leftoverIds);
+
+    return sections;
+};
+
+const CompanionCard = ({ companion, enabledIds, activeWriteId, writeStatus, onToggle }) =>
+    div(
+        {
+            class: () =>
+                [
+                    "companion-card",
+                    enabledIds.val.has(companion.id) && "companion-card--enabled",
+                    activeWriteId.val === companion.id && writeStatus.val === "loading" && "companion-card--loading",
+                ]
+                    .filter(Boolean)
+                    .join(" "),
+            onclick: () => onToggle(companion.id),
+            title: "Left click: toggle this pet's account bonus.",
+        },
+        div(
+            { class: "companion-card__top" },
+            div({ class: "companion-card__name" }, companion.name),
+            span({ class: "companion-card__id" }, `ID ${companion.id}`)
+        ),
+        div({ class: "companion-card__effect" }, companion.effect)
+    );
+
+export const CompanionsTab = () => {
+    const { loading, error, run: runLoad } = useAccountLoad({ label: "Pets" });
+    const { status: writeStatus, run: runWrite } = useWriteStatus();
+
+    const companions = van.state([]);
+    const sections = van.state([]);
+    const validIds = van.state([]);
+    const enabledIds = van.state(new Set());
+    const activeWriteId = van.state(null);
+    const hideUnused = van.state(false);
+    const searchQuery = van.state("");
+
+    const eligibleIds = () => companions.val.filter((companion) => !companion.isUnused).map((companion) => companion.id);
+
+    const load = () =>
+        runLoad(async () => {
+            const [rawCompanionDb, rawSetsInfo] = await Promise.all([
+                readCList("CompanionDB"),
+                readCList("CompanionSetsInfo"),
+            ]);
+            const monsterKeys = [
+                ...new Set(toIndexedArray(rawCompanionDb).map((entry) => toIndexedArray(entry)[0]).filter(Boolean)),
+            ];
+            const monsterDefs = monsterKeys.length
+                ? await readGgaEntries("MonsterDefinitionsGET.h", monsterKeys, ["Name"])
+                : {};
+
+            const nextCompanions = buildCompanionRows(rawCompanionDb, monsterDefs);
+            const nextValidIds = nextCompanions.map((companion) => companion.id);
+            const validIdSet = new Set(nextValidIds);
+
+            companions.val = nextCompanions;
+            sections.val = buildSections(nextCompanions, rawSetsInfo);
+            validIds.val = nextValidIds;
+
+            const tokenValue = await gga(TOKEN_PATH);
+            enabledIds.val = new Set(parseIdList(tokenValue).filter((id) => validIdSet.has(id)));
+        });
+
+    const writeTokens = (idSet) =>
+        runWrite(async () => {
+            await writeVerified(TOKEN_PATH, serializeIds(idSet));
+            enabledIds.val = idSet;
+        });
+
+    const handleToggle = async (companionId) => {
+        if (activeWriteId.val !== null) return;
+        activeWriteId.val = companionId;
+
+        const next = new Set(enabledIds.val);
+        if (next.has(companionId)) next.delete(companionId);
+        else next.add(companionId);
+
+        await writeTokens(next);
+        activeWriteId.val = null;
+    };
+
+    const handleBulkWrite = async (ids) => {
+        if (activeWriteId.val !== null) return;
+        await writeTokens(new Set(ids));
+    };
+
+    const isBusy = () => activeWriteId.val !== null || writeStatus.val === "loading";
+
+    load();
+
+    const renderSearchResults = () => {
+        const companionMap = new Map(companions.val.map((companion) => [companion.id, companion]));
+        const query = normalizeSearchText(searchQuery.val);
+        const matchesFilters = (companion) => {
+            if (!companion) return false;
+            if (hideUnused.val && companion.isUnused) return false;
+            if (!query) return true;
+            return (
+                normalizeSearchText(companion.name).includes(query) ||
+                normalizeSearchText(companion.effect).includes(query)
+            );
+        };
+        const visibleSections = sections.val
+            .map((section) => ({
+                ...section,
+                companions: section.ids.map((id) => companionMap.get(id)).filter(matchesFilters),
+            }))
+            .filter((section) => section.companions.length > 0);
+
+        if (!visibleSections.length) {
+            return EmptyState({
+                icon: Icons.SearchX(),
+                title: "NO MATCHING PETS",
+                subtitle: query
+                    ? "No pets matched your current search."
+                    : "No pets remain after the current filters were applied.",
+            });
+        }
+
+        return div(
+            ...visibleSections.map((section) =>
+                div(
+                    { class: "companions-section" },
+                    div({ class: "companions-section__title" }, section.label),
+                    div(
+                        { class: "companions-grid" },
+                        ...section.companions.map((companion) =>
+                            CompanionCard({ companion, enabledIds, activeWriteId, writeStatus, onToggle: handleToggle })
+                        )
+                    )
+                )
+            )
+        );
+    };
+
+    const subNav = div(
+        { class: "control-bar sticky-header" },
+        SearchBar({
+            placeholder: "SEARCH PETS OR BUFFS",
+            onInput: (value) => (searchQuery.val = value),
+        }),
+        withTooltip(
+            label(
+                { class: "toggle-switch account-toggle" },
+                input({
+                    type: "checkbox",
+                    checked: () => hideUnused.val,
+                    onchange: (e) => (hideUnused.val = e.target.checked),
+                }),
+                span({ class: "slider" }),
+                span({ class: "label" }, "HIDE UNUSED")
+            ),
+            "Hide pets that are not part of the official in-game pet groups."
+        ),
+        withTooltip(
+            button(
+                { class: "btn-secondary", onclick: () => handleBulkWrite(eligibleIds()), disabled: () => isBusy() },
+                "UNLOCK ALL"
+            ),
+            "Activate the bonus of every available pet."
+        ),
+        withTooltip(
+            button({ class: "btn-secondary", onclick: () => handleBulkWrite([]), disabled: () => isBusy() }, "CLEAR ALL"),
+            "Deactivate all pet bonuses."
+        )
+    );
+
+    return PersistentAccountListPage({
+        rootClass: "tab-container",
+        title: "PETS",
+        description: "Left click toggles a pet's account-wide bonus (pet token). Writes bypass the in-game token limit.",
+        actions: RefreshButton({ onRefresh: load, tooltip: "Re-read live companion data from the running game." }),
+        subNav,
+        state: { loading, error },
+        loadingText: "READING PETS",
+        errorTitle: "PET READ FAILED",
+        body: div({ class: "scrollable-panel companions-scroll" }, () => renderSearchResults()),
+    });
+};

--- a/src/ui/components/views/account/w1/CompanionsTab.js
+++ b/src/ui/components/views/account/w1/CompanionsTab.js
@@ -117,8 +117,9 @@ const buildSections = (pets, rawSetsInfo) => {
 };
 
 const CompanionCard = ({ companion, enabledIds, activeWriteId, writeStatus, onToggle }) =>
-    div(
+    button(
         {
+            type: "button",
             class: () =>
                 [
                     "companion-card",
@@ -127,8 +128,9 @@ const CompanionCard = ({ companion, enabledIds, activeWriteId, writeStatus, onTo
                 ]
                     .filter(Boolean)
                     .join(" "),
+            "aria-pressed": () => enabledIds.val.has(companion.id),
             onclick: () => onToggle(companion.id),
-            title: "Left click: toggle this pet's account bonus.",
+            title: "Click: toggle this pet's account bonus.",
         },
         div(
             { class: "companion-card__top" },
@@ -183,24 +185,27 @@ export const CompanionsTab = () => {
             enabledIds.val = idSet;
         });
 
+    const isBusy = () => loading.val || activeWriteId.val !== null || writeStatus.val === "loading";
+
     const handleToggle = async (companionId) => {
-        if (activeWriteId.val !== null) return;
+        if (isBusy()) return;
         activeWriteId.val = companionId;
 
-        const next = new Set(enabledIds.val);
-        if (next.has(companionId)) next.delete(companionId);
-        else next.add(companionId);
+        try {
+            const next = new Set(enabledIds.val);
+            if (next.has(companionId)) next.delete(companionId);
+            else next.add(companionId);
 
-        await writeTokens(next);
-        activeWriteId.val = null;
+            await writeTokens(next);
+        } finally {
+            activeWriteId.val = null;
+        }
     };
 
     const handleBulkWrite = async (ids) => {
-        if (activeWriteId.val !== null) return;
+        if (isBusy()) return;
         await writeTokens(new Set(ids));
     };
-
-    const isBusy = () => activeWriteId.val !== null || writeStatus.val === "loading";
 
     load();
 

--- a/src/ui/components/views/account/w1/CompanionsTab.js
+++ b/src/ui/components/views/account/w1/CompanionsTab.js
@@ -21,7 +21,7 @@ import { toIndexedArray } from "../../../../utils/index.js";
 import { RefreshButton } from "../components/AccountPageChrome.js";
 import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
 import { useAccountLoad } from "../accountLoadPolicy.js";
-import { useWriteStatus, writeVerified } from "../accountShared.js";
+import { cleanName, cleanNameEffect, useWriteStatus, writeVerified } from "../accountShared.js";
 
 const { div, button, span, label, input } = van.tags;
 
@@ -32,14 +32,6 @@ const normalizeSearchText = (value) => String(value ?? "").trim().toLowerCase();
 const isUnusedPetText = (value) => {
     const text = normalizeSearchText(value);
     return text.includes("not officially in the game") && text.includes("may never be");
-};
-
-const cleanText = (value, fallback = "") => {
-    const text = String(value ?? fallback)
-        .replace(/_/g, " ")
-        .replace(/^\{+\s*/, "")
-        .trim();
-    return text || fallback;
 };
 
 const parseIdList = (value) =>
@@ -69,10 +61,10 @@ const buildCompanionRows = (rawCompanionDb, rawMonsterDefs) =>
         .map((entry, id) => {
             const row = toIndexedArray(entry);
             const monsterKey = row[0];
-            const name = cleanText(rawMonsterDefs?.[monsterKey]?.Name, "");
+            const name = cleanName(rawMonsterDefs?.[monsterKey]?.Name, "");
             if (!name) return null;
 
-            const effect = cleanText(row[1], "No buff text");
+            const effect = cleanNameEffect(row[1], "No buff text");
 
             return { id, monsterKey, name, effect, isUnused: isUnusedPetText(effect) };
         })
@@ -116,16 +108,12 @@ const buildSections = (pets, rawSetsInfo) => {
     return sections;
 };
 
-const CompanionCard = ({ companion, enabledIds, activeWriteId, writeStatus, onToggle }) =>
+const CompanionCard = ({ companion, enabledIds, onToggle }) =>
     button(
         {
             type: "button",
             class: () =>
-                [
-                    "companion-card",
-                    enabledIds.val.has(companion.id) && "companion-card--enabled",
-                    activeWriteId.val === companion.id && writeStatus.val === "loading" && "companion-card--loading",
-                ]
+                ["companion-card", enabledIds.val.has(companion.id) && "companion-card--enabled"]
                     .filter(Boolean)
                     .join(" "),
             "aria-pressed": () => enabledIds.val.has(companion.id),
@@ -146,9 +134,7 @@ export const CompanionsTab = () => {
 
     const companions = van.state([]);
     const sections = van.state([]);
-    const validIds = van.state([]);
     const enabledIds = van.state(new Set());
-    const activeWriteId = van.state(null);
     const hideUnused = van.state(false);
     const searchQuery = van.state("");
 
@@ -168,12 +154,10 @@ export const CompanionsTab = () => {
                 : {};
 
             const nextCompanions = buildCompanionRows(rawCompanionDb, monsterDefs);
-            const nextValidIds = nextCompanions.map((companion) => companion.id);
-            const validIdSet = new Set(nextValidIds);
+            const validIdSet = new Set(nextCompanions.map((companion) => companion.id));
 
             companions.val = nextCompanions;
             sections.val = buildSections(nextCompanions, rawSetsInfo);
-            validIds.val = nextValidIds;
 
             const tokenValue = await gga(TOKEN_PATH);
             enabledIds.val = new Set(parseIdList(tokenValue).filter((id) => validIdSet.has(id)));
@@ -185,21 +169,16 @@ export const CompanionsTab = () => {
             enabledIds.val = idSet;
         });
 
-    const isBusy = () => loading.val || activeWriteId.val !== null || writeStatus.val === "loading";
+    const isBusy = () => loading.val || writeStatus.val === "loading";
 
     const handleToggle = async (companionId) => {
         if (isBusy()) return;
-        activeWriteId.val = companionId;
 
-        try {
-            const next = new Set(enabledIds.val);
-            if (next.has(companionId)) next.delete(companionId);
-            else next.add(companionId);
+        const next = new Set(enabledIds.val);
+        if (next.has(companionId)) next.delete(companionId);
+        else next.add(companionId);
 
-            await writeTokens(next);
-        } finally {
-            activeWriteId.val = null;
-        }
+        await writeTokens(next);
     };
 
     const handleBulkWrite = async (ids) => {
@@ -246,7 +225,7 @@ export const CompanionsTab = () => {
                     div(
                         { class: "companions-grid" },
                         ...section.companions.map((companion) =>
-                            CompanionCard({ companion, enabledIds, activeWriteId, writeStatus, onToggle: handleToggle })
+                            CompanionCard({ companion, enabledIds, onToggle: handleToggle })
                         )
                     )
                 )

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -68,11 +68,6 @@
     background: var(--c-success-10);
 }
 
-.companion-card--loading {
-    opacity: 0.65;
-    cursor: wait;
-}
-
 .companion-card__top {
     display: flex;
     align-items: flex-start;

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -10,13 +10,11 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    padding-top: 6px;
-    border-top: 1px solid var(--c-border);
+    padding-top: 12px;
 }
 
 .companions-section:first-child {
     padding-top: 0;
-    border-top: 0;
 }
 
 .companions-section__title {
@@ -24,7 +22,8 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     color: var(--c-text-dim);
-    margin-top: 2px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--c-border);
 }
 
 .companions-grid {

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -1,0 +1,97 @@
+/* ── Pets (W1 Companions) ──────────────────────────────────────────────── */
+
+.companions-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.companions-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 6px;
+    border-top: 1px solid var(--c-border);
+}
+
+.companions-section:first-child {
+    padding-top: 0;
+    border-top: 0;
+}
+
+.companions-section__title {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--c-text-dim);
+    margin-top: 2px;
+}
+
+.companions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 10px;
+}
+
+.companion-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    background: var(--c-panel);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition:
+        border-color 0.15s,
+        background 0.15s,
+        box-shadow 0.15s;
+    user-select: none;
+}
+
+.companion-card:hover {
+    border-color: var(--c-accent);
+    background: var(--c-panel-hover);
+}
+
+.companion-card--enabled {
+    border-color: var(--c-success);
+    background: var(--c-success-10);
+}
+
+.companion-card--loading {
+    opacity: 0.65;
+    cursor: wait;
+}
+
+.companion-card__top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.companion-card__name {
+    min-width: 0;
+    flex: 1;
+    font-size: 0.86rem;
+    font-weight: 700;
+    color: var(--c-text-main);
+    line-height: 1.25;
+}
+
+.companion-card__id {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--c-text-muted);
+    background: var(--c-black-40);
+    padding: 2px 6px;
+}
+
+.companion-card__effect {
+    min-height: 2.7em;
+    font-size: 0.75rem;
+    color: var(--c-text-dim);
+    line-height: 1.45;
+}

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -38,6 +38,11 @@
     flex-direction: column;
     gap: 8px;
     padding: 10px 12px;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    appearance: none;
     background: var(--c-panel);
     border: 1px solid var(--c-border);
     border-radius: var(--radius-md);
@@ -52,6 +57,11 @@
 .companion-card:hover {
     border-color: var(--c-accent);
     background: var(--c-panel-hover);
+}
+
+.companion-card:focus-visible {
+    outline: 2px solid var(--c-accent);
+    outline-offset: 2px;
 }
 
 .companion-card--enabled {

--- a/src/ui/styles/tabs/w1/_index.css
+++ b/src/ui/styles/tabs/w1/_index.css
@@ -1,3 +1,4 @@
+@import url("./_companions.css");
 @import url("./_forge.css");
 @import url("./_stamps.css");
 @import url("./_starsigns.css");


### PR DESCRIPTION
## What

Adds a **PETS** sub-tab under World 1 that lists every companion from `CompanionDB` (auto-populated, searchable, with buff descriptions and a hide-unused filter) and lets you toggle each pet's account-wide bonus on or off.

Selection is stored as the game's own pet-bonus token list, `OptionsListAccount[606]` — a CSV of `CompanionDB` indices. The game applies `DNSM.h.CompanionBon[id] = CompanionDB[id][2]` for each listed id every tick, so toggling a pet activates its bonus immediately. Writing the list directly bypasses the in-game one-token-at-a-time limit (`PetBonusTokensLeft = PetBonusTokensOwned - count(606)`), letting you enable any combination. **UNLOCK ALL** / **CLEAR ALL** write the full eligible set or an empty list.

## How

- Toggle / bulk writes go through the existing `gga()` / `writeVerified()` helpers — writes are verified.
- Built on the existing account-page conventions: `PersistentAccountListPage`, `useAccountLoad`, `useWriteStatus`, `RefreshButton`, `SearchBar`.
- Eligible pets = rows with a name and a real effect (`row[1] !== "Not_officially_in_the_game_and_may_never_be"`).

## Scope

Purely additive — **no backend/proxy changes**:

- `src/ui/components/views/account/w1/CompanionsTab.js` (new)
- `src/ui/styles/tabs/w1/_companions.css` (new)
- `src/ui/components/views/account/W1Tab.js` (register sub-tab)
- `src/ui/styles/tabs/w1/_index.css` (import css)
- `src/ui/components/Tooltip.js` (dismiss tooltip on click so it doesn't linger after clicking a control)

## Notes

- Writing more pets than tokens owned makes the in-game `PetBonusTokensLeft` counter show negative; bonuses still apply (the apply loop ignores token count).
- Persists via the normal cloud save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Pets” (W1 Companions) sub-tab with searchable companion cards and an option to hide unused entries.
  * Supports unlock all and clear all actions, plus individual enable/disable toggles.
  * Includes loading/error handling and an empty state when no results match.
  * Added dedicated styling and layout for the companions section and cards.

* **Bug Fixes**
  * Tooltips now close when the target item is clicked (not only on mouse leave).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->