### PR TITLE
feat(ui): add account cards editor

### DIFF
--- a/src/ui/assets/icons.js
+++ b/src/ui/assets/icons.js
@@ -1,6 +1,18 @@
 import van from "../vendor/van-1.6.0.js";
 
-const { svg, path, circle, line, rect, polyline, polygon, g, defs, mask } = van.tags("http://www.w3.org/2000/svg");
+const {
+    svg,
+    path,
+    circle,
+    line,
+    rect,
+    polyline,
+    polygon,
+    text: svgText,
+    g,
+    defs,
+    mask,
+} = van.tags("http://www.w3.org/2000/svg");
 
 const SvgBase = (content, props = {}) => {
     const { class: className, ...rest } = props;
@@ -146,6 +158,31 @@ export const Icons = {
             }),
             { fill: "currentColor", stroke: "none", "aria-hidden": "true", ...props }
         ),
+
+    CardTier: (tier, props = {}) => {
+        const label = Math.min(6, Math.max(1, Math.round(Number(tier) || 1)));
+
+        return SvgBase(
+            [
+                polygon({ points: "12 1.75 20.88 6.88 20.88 17.12 12 22.25 3.12 17.12 3.12 6.88" }),
+                svgText(
+                    {
+                        x: "12",
+                        y: "12.5",
+                        fill: "currentColor",
+                        stroke: "none",
+                        "text-anchor": "middle",
+                        "dominant-baseline": "middle",
+                        "font-family": "sans-serif",
+                        "font-size": "10",
+                        "font-weight": "700",
+                    },
+                    String(label)
+                ),
+            ],
+            { "stroke-width": "1.75", "aria-hidden": "true", ...props }
+        );
+    },
 
     Refresh: (props) =>
         SvgBase([path({ d: "M23 4v6h-6" }), path({ d: "M20.49 15a9 9 0 1 1-2.12-9.36L23 10" })], {

--- a/src/ui/components/views/Account.js
+++ b/src/ui/components/views/Account.js
@@ -10,6 +10,7 @@
 
 import van from "../../vendor/van-1.6.0.js";
 import { AccountOptionsTab } from "./account/AccountOptionsTab.js";
+import { CardsTab } from "./account/CardsTab.js";
 import { TasksTab } from "./account/TasksTab.js";
 import { UpgradeVaultTab } from "./account/UpgradeVaultTab.js";
 import { W1Tab } from "./account/W1Tab.js";
@@ -31,6 +32,7 @@ const ACCOUNT_TABS = [
     { id: "account-options", label: "ACCOUNT OPTIONS", isWorld: false, component: AccountOptionsTab },
     { id: "upgrade-vault", label: "UPGRADE VAULT", isWorld: false, component: UpgradeVaultTab },
     { id: "tasks", label: "TASKS", isWorld: false, component: TasksTab },
+    { id: "cards", label: "CARDS", isWorld: false, component: CardsTab },
     { id: "w1", label: "BLUNDER HILLS", isWorld: true, worldNum: 1, component: W1Tab },
     { id: "w2", label: "YUM-YUM DESERT", isWorld: true, worldNum: 2, component: W2Tab },
     { id: "w3", label: "FROSTBITE TUNDRA", isWorld: true, worldNum: 3, component: W3Tab },
@@ -51,8 +53,11 @@ export const Account = () => {
             tabs: ACCOUNT_TABS,
             activeId: activeTab,
             navClass: "account-sub-nav",
-            buttonClass: (tab) =>
-                `account-top-tab-btn ${tab.isWorld ? `world-tab-btn w${tab.worldNum}-world-tab` : "account-options-btn"}`,
+            buttonClass: (tab) => {
+                if (tab.isWorld) return `account-top-tab-btn world-tab-btn w${tab.worldNum}-world-tab`;
+                const compactClass = tab.id === "tasks" || tab.id === "cards" ? "account-compact-tab-btn" : "";
+                return `account-top-tab-btn account-options-btn ${compactClass}`;
+            },
             renderLabel: (tab) => (tab.isWorld ? span({ class: "world-tab-btn-num" }, `W${tab.worldNum}`) : tab.label),
             getButtonProps: (tab) => ({ title: tab.label }),
         }),

--- a/src/ui/components/views/account/CardsTab.js
+++ b/src/ui/components/views/account/CardsTab.js
@@ -21,7 +21,7 @@ import { RefreshButton } from "./components/AccountPageChrome.js";
 import { ActionButton } from "./components/ActionButton.js";
 import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
 
-const { div, span, button, details, summary, h3, p } = van.tags;
+const { div, span, select, option, details, summary, h3, p } = van.tags;
 
 const CARD_PATH = "Cards[0].h";
 const TIER_MULTIPLIERS = [1, 3, 5, 16, 459, 14645];
@@ -42,16 +42,8 @@ const CARD_REGION_NAMES = [
 ];
 
 const toUnwrappedIndexedArray = (value) => toIndexedArray(unwrapH(value));
-const cardPath = (monsterId) => `${CARD_PATH}.${monsterId}`;
-const tierThresholds = (baseRequirement) => TIER_MULTIPLIERS.map((multiplier) => baseRequirement * multiplier);
-
-const tierIndexForAmount = (amount, thresholds) => {
-    let currentTier = -1;
-    thresholds.forEach((threshold, index) => {
-        if (Number(amount) >= threshold) currentTier = index;
-    });
-    return currentTier;
-};
+const tierIndexForAmount = (amount, thresholds) =>
+    thresholds.findLastIndex((threshold) => Number(amount) >= threshold);
 
 const nextTierLabel = (amount, thresholds) => {
     const nextThreshold = thresholds.find((threshold) => Number(amount) < threshold);
@@ -74,74 +66,43 @@ const TierBadgeContent = ({ amount, thresholds }) => {
     );
 };
 
-const closeOtherTierPickers = (activePicker) => {
-    document.querySelectorAll(".card-tier-picker[open]").forEach((picker) => {
-        if (picker !== activePicker) picker.open = false;
-    });
-};
-
-const TierPicker = ({
+const TierSelect = ({
     label = "SET TIER",
     thresholds = null,
     onSelect,
     status = null,
     disabled = false,
     className = "",
-    triggerVariant = "apply",
 }) => {
     const isDisabled = () => Boolean(resolveValue(disabled)) || resolveValue(status) === "loading";
 
-    const picker = details(
+    return select(
         {
             class: () => {
                 const resolvedStatus = resolveValue(status);
                 return joinClasses(
-                    "card-tier-picker",
+                    "select-base card-tier-select",
                     resolveValue(className),
-                    resolvedStatus === "loading" ? "card-tier-picker--loading" : "",
-                    resolvedStatus === "success" ? "card-tier-picker--success" : "",
-                    resolvedStatus === "error" ? "card-tier-picker--error" : ""
+                    resolvedStatus === "loading" ? "card-tier-select--loading" : "",
+                    resolvedStatus === "success" ? "card-tier-select--success" : "",
+                    resolvedStatus === "error" ? "card-tier-select--error" : ""
                 );
             },
-            ontoggle: () => {
-                if (picker.open) closeOtherTierPickers(picker);
+            disabled: isDisabled,
+            onchange: async (event) => {
+                const tierIndex = Number(event.target.value);
+                event.target.value = "";
+                await onSelect(tierIndex, thresholds?.[tierIndex]);
             },
         },
-        summary(
-            {
-                class: `account-btn account-btn--${triggerVariant} card-tier-picker__trigger`,
-                "aria-disabled": () => String(isDisabled()),
-                onclick: (event) => {
-                    if (isDisabled()) event.preventDefault();
-                },
-            },
-            span(label),
-            Icons.ChevronRight({ class: "card-tier-picker__chevron" })
-        ),
-        div(
-            { class: "card-tier-picker__menu" },
-            ...TIER_MULTIPLIERS.map((_, tierIndex) =>
-                button(
-                    {
-                        type: "button",
-                        class: `card-tier-picker__option card-tier-picker__option--tier-${tierIndex + 1}`,
-                        disabled: isDisabled,
-                        onclick: async (event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            picker.open = false;
-                            await onSelect(tierIndex, thresholds?.[tierIndex]);
-                        },
-                    },
-                    Icons.CardTier(tierIndex + 1, { class: "card-tier-icon" }),
-                    span(`TIER ${tierIndex + 1}`),
-                    span({ class: "card-tier-picker__amount" }, thresholds ? String(thresholds[tierIndex]) : "PER CARD")
-                )
+        option({ value: "", disabled: true, selected: true }, label),
+        ...TIER_MULTIPLIERS.map((_, tierIndex) =>
+            option(
+                { value: tierIndex },
+                `TIER ${tierIndex + 1} - ${thresholds ? thresholds[tierIndex] : "PER CARD"}`
             )
         )
     );
-
-    return picker;
 };
 
 const CardRow = ({ card, valueState }) =>
@@ -160,7 +121,7 @@ const CardRow = ({ card, valueState }) =>
             ),
         renderBadge: (currentValue) => TierBadgeContent({ amount: currentValue, thresholds: card.thresholds }),
         renderExtraActions: ({ status, applyValue }) =>
-            TierPicker({
+            TierSelect({
                 thresholds: card.thresholds,
                 status,
                 onSelect: (_, threshold) => applyValue(threshold),
@@ -206,9 +167,9 @@ const buildCardData = async (rawCards, rawCardStuff) => {
                 return {
                     monsterId,
                     baseRequirement,
-                    thresholds: tierThresholds(baseRequirement),
+                    thresholds: TIER_MULTIPLIERS.map((multiplier) => baseRequirement * multiplier),
                     amount: toInt(accountCards[monsterId], { min: 0 }),
-                    path: cardPath(monsterId),
+                    path: `${CARD_PATH}.${monsterId}`,
                 };
             })
             .filter(Boolean);
@@ -240,88 +201,65 @@ const buildCardData = async (rawCards, rawCardStuff) => {
         unresolved.push({
             monsterId,
             amount: toInt(accountCards[monsterId], { min: 0 }),
-            path: cardPath(monsterId),
+            path: `${CARD_PATH}.${monsterId}`,
         });
     });
 
     return { regions, unresolved, total: accountIds.length };
 };
 
-const RegionSection = ({ region, openState, valueStates, bulkStatus, activeBulkRegion, requestBulkWrite }) => {
-    const bodyId = `card-region-${region.index}`;
-    const status = () => (activeBulkRegion.val === region.key ? bulkStatus.val : null);
+const CardSection = ({
+    region,
+    openState,
+    valueStates,
+    bulkStatus = null,
+    activeBulkRegion = null,
+    requestBulkWrite = null,
+    unresolved = false,
+}) => {
+    const status = () => (requestBulkWrite && activeBulkRegion.val === region.key ? bulkStatus.val : null);
+    const Row = unresolved ? UnresolvedCardRow : CardRow;
 
     return div(
         {
             class: () =>
                 joinClasses(
                     "card-region",
-                    openState.val ? "card-region--open" : "",
+                    unresolved ? "card-region--unresolved" : "",
                     status() === "success" ? "card-region--success" : "",
                     status() === "error" ? "card-region--error" : ""
                 ),
         },
-        div(
-            { class: "card-region__header" },
-            button(
-                {
-                    type: "button",
-                    class: "card-region__toggle",
-                    "aria-expanded": () => String(openState.val),
-                    "aria-controls": bodyId,
-                    onclick: () => (openState.val = !openState.val),
-                },
+        details(
+            {
+                class: "card-region__details",
+                open: openState,
+                ontoggle: (event) => (openState.val = event.target.open),
+            },
+            summary(
+                { class: "card-region__toggle" },
                 Icons.ChevronRight({ class: "card-region__chevron" }),
                 span({ class: "card-region__title" }, region.name),
                 span({ class: "card-region__count" }, `${region.cards.length} CARDS`)
             ),
-            TierPicker({
+            div(
+                { class: "card-region__body account-item-stack" },
+                ...region.cards.map((card) =>
+                    Row({ card, valueState: getOrCreateState(valueStates, card.monsterId) })
+                )
+            )
+        ),
+        requestBulkWrite
+            ? TierSelect({
                 label: "SET REGION TIER",
                 status,
                 disabled: () => region.cards.length === 0,
-                className: "card-region__tier-picker",
-                triggerVariant: "max-reset",
+                className: "card-region__tier-select",
                 onSelect: (tierIndex) => requestBulkWrite(region, tierIndex),
             })
-        ),
-        div(
-            {
-                id: bodyId,
-                class: () => joinClasses("card-region__body account-item-stack", !openState.val ? "is-hidden" : ""),
-            },
-            ...region.cards.map((card) => CardRow({ card, valueState: getOrCreateState(valueStates, card.monsterId) }))
-        )
+            : null
     );
 };
-
-const UnresolvedSection = ({ cards, openState, valueStates }) =>
-    div(
-        { class: () => joinClasses("card-region card-region--unresolved", openState.val ? "card-region--open" : "") },
-        div(
-            { class: "card-region__header" },
-            button(
-                {
-                    type: "button",
-                    class: "card-region__toggle",
-                    "aria-expanded": () => String(openState.val),
-                    "aria-controls": "card-region-unresolved",
-                    onclick: () => (openState.val = !openState.val),
-                },
-                Icons.ChevronRight({ class: "card-region__chevron" }),
-                span({ class: "card-region__title" }, "UNRESOLVED CARDS"),
-                span({ class: "card-region__count" }, `${cards.length} CARDS`)
-            )
-        ),
-        div(
-            {
-                id: "card-region-unresolved",
-                class: () => joinClasses("card-region__body account-item-stack", !openState.val ? "is-hidden" : ""),
-            },
-            ...cards.map((card) =>
-                UnresolvedCardRow({ card, valueState: getOrCreateState(valueStates, card.monsterId) })
-            )
-        )
-    );
 
 const BulkConfirmationModal = ({ pending, status, onCancel, onConfirm }) =>
     div(
@@ -397,7 +335,7 @@ export const CardsTab = () => {
 
             reconcileRegions(signature, () => [
                 ...data.regions.map((region) =>
-                    RegionSection({
+                    CardSection({
                         region,
                         openState: getOpenState(region.key),
                         valueStates: amountStates,
@@ -408,10 +346,15 @@ export const CardsTab = () => {
                 ),
                 ...(data.unresolved.length
                     ? [
-                          UnresolvedSection({
-                              cards: data.unresolved,
+                          CardSection({
+                              region: {
+                                  key: "unresolved",
+                                  name: "UNRESOLVED CARDS",
+                                  cards: data.unresolved,
+                              },
                               openState: getOpenState("unresolved"),
                               valueStates: amountStates,
+                              unresolved: true,
                           }),
                       ]
                     : []),

--- a/src/ui/components/views/account/CardsTab.js
+++ b/src/ui/components/views/account/CardsTab.js
@@ -18,10 +18,9 @@ import {
     writeVerified,
 } from "./accountShared.js";
 import { RefreshButton } from "./components/AccountPageChrome.js";
-import { ActionButton } from "./components/ActionButton.js";
 import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
 
-const { div, span, select, option, details, summary, h3, p } = van.tags;
+const { div, span, select, option, details, summary } = van.tags;
 
 const CARD_PATH = "Cards[0].h";
 const TIER_MULTIPLIERS = [1, 3, 5, 16, 459, 14645];
@@ -218,10 +217,10 @@ const CardSection = ({
     valueStates,
     bulkStatus = null,
     activeBulkRegion = null,
-    requestBulkWrite = null,
+    setRegionTier = null,
     unresolved = false,
 }) => {
-    const status = () => (requestBulkWrite && activeBulkRegion.val === region.key ? bulkStatus.val : null);
+    const status = () => (setRegionTier && activeBulkRegion.val === region.key ? bulkStatus.val : null);
     const Row = unresolved ? UnresolvedCardRow : CardRow;
 
     return div(
@@ -253,57 +252,17 @@ const CardSection = ({
                 )
             )
         ),
-        requestBulkWrite
+        setRegionTier
             ? TierSelect({
                 label: "SET REGION TIER",
                 status,
                 disabled: () => region.cards.length === 0,
                 className: "card-region__tier-select",
-                onSelect: (tierIndex) => requestBulkWrite(region, tierIndex),
+                onSelect: (tierIndex) => setRegionTier(region, tierIndex),
             })
             : null
     );
 };
-
-const BulkConfirmationModal = ({ pending, status, onCancel, onConfirm }) =>
-    div(
-        {
-            class: () => joinClasses("modal cards-bulk-modal", !pending.val ? "is-hidden" : ""),
-            onclick: () => {
-                if (status.val !== "loading") onCancel();
-            },
-        },
-        div(
-            { class: "modal-box cards-bulk-modal__box", onclick: (event) => event.stopPropagation() },
-            div(
-                { class: "modal-header" },
-                h3(() => (pending.val ? `SET ${pending.val.region.name} TO TIER ${pending.val.tierIndex + 1}?` : ""))
-            ),
-            div(
-                { class: "modal-body cards-bulk-modal__body" },
-                p(() => {
-                    if (!pending.val) return "";
-                    return `${pending.val.affectedCount} of ${pending.val.region.cards.length} cards will change.`;
-                }),
-                p("Each card will be set to its own minimum Card Amount for the selected tier.")
-            ),
-            div(
-                { class: "modal-footer" },
-                ActionButton({
-                    label: "CANCEL",
-                    variant: "max-reset",
-                    disabled: () => status.val === "loading",
-                    onClick: onCancel,
-                }),
-                ActionButton({
-                    label: () => (pending.val ? `SET TIER ${pending.val.tierIndex + 1}` : "SET TIER"),
-                    status,
-                    disabled: () => !pending.val || pending.val.affectedCount === 0,
-                    onClick: onConfirm,
-                })
-            )
-        )
-    );
 
 export const CardsTab = () => {
     const { loading, error, run: runLoad } = useAccountLoad({ label: "Cards" });
@@ -312,18 +271,10 @@ export const CardsTab = () => {
     const amountStates = new Map();
     const openStates = new Map();
     const activeBulkRegion = van.state(null);
-    const pendingBulk = van.state(null);
     const regionsNode = div({ class: "cards-regions" });
     const reconcileRegions = createStaticRowReconciler(regionsNode);
 
     const getOpenState = (key) => getOrCreateState(openStates, key, false);
-
-    const requestBulkWrite = (region, tierIndex) => {
-        const affectedCount = region.cards.filter(
-            (card) => getOrCreateState(amountStates, card.monsterId).val !== card.thresholds[tierIndex]
-        ).length;
-        pendingBulk.val = { region, tierIndex, affectedCount };
-    };
 
     const load = () =>
         runLoad(async () => {
@@ -345,7 +296,7 @@ export const CardsTab = () => {
                         valueStates: amountStates,
                         bulkStatus,
                         activeBulkRegion,
-                        requestBulkWrite,
+                        setRegionTier,
                     })
                 ),
                 ...(data.unresolved.length
@@ -371,44 +322,28 @@ export const CardsTab = () => {
             totalCards.val = data.total;
         });
 
-    const confirmBulkWrite = async () => {
-        const pending = pendingBulk.val;
-        if (!pending || bulkStatus.val === "loading") return;
+    async function setRegionTier(region, tierIndex) {
+        if (bulkStatus.val === "loading") return;
 
-        activeBulkRegion.val = pending.region.key;
+        activeBulkRegion.val = region.key;
         const result = await runBulk(() =>
             runBulkSet({
-                entries: pending.region.cards,
-                getTargetValue: (card) => card.thresholds[pending.tierIndex],
+                entries: region.cards,
+                getTargetValue: (card) => card.thresholds[tierIndex],
                 getValueState: (card) => getOrCreateState(amountStates, card.monsterId),
                 getPath: (card) => card.path,
             })
         );
 
-        pendingBulk.val = null;
         if (!result.ok) {
-            getOpenState(pending.region.key).val = true;
+            getOpenState(region.key).val = true;
             await load();
         }
-    };
+    }
 
     load();
 
-    const body = div(
-        { class: "cards-page-content" },
-        div({ class: "scrollable-panel cards-scroll" }, regionsNode),
-        BulkConfirmationModal({
-            pending: pendingBulk,
-            status: bulkStatus,
-            onCancel: () => {
-                if (bulkStatus.val !== "loading") pendingBulk.val = null;
-            },
-            onConfirm: (event) => {
-                event.preventDefault();
-                void confirmBulkWrite();
-            },
-        })
-    );
+    const body = div({ class: "cards-page-content" }, div({ class: "scrollable-panel cards-scroll" }, regionsNode));
 
     return PersistentAccountListPage({
         title: "CARDS",

--- a/src/ui/components/views/account/CardsTab.js
+++ b/src/ui/components/views/account/CardsTab.js
@@ -152,7 +152,6 @@ const UnresolvedCardRow = ({ card, valueState }) =>
 const buildCardData = async (rawCards, rawCardStuff) => {
     const accountCards = unwrapH(rawCards) ?? {};
     const accountIds = Object.keys(accountCards);
-    const accountIdSet = new Set(accountIds);
     const matchedIds = new Set();
 
     const regions = CARD_REGION_NAMES.map((name, regionIndex) => {
@@ -160,7 +159,7 @@ const buildCardData = async (rawCards, rawCardStuff) => {
             .map((rawDefinition) => {
                 const definition = toUnwrappedIndexedArray(rawDefinition);
                 const monsterId = String(definition[0] ?? "").trim();
-                if (!monsterId || !accountIdSet.has(monsterId) || matchedIds.has(monsterId)) return null;
+                if (!monsterId || monsterId === "Blank" || matchedIds.has(monsterId)) return null;
 
                 matchedIds.add(monsterId);
                 const baseRequirement = toInt(definition[2], { min: 0 });
@@ -169,7 +168,7 @@ const buildCardData = async (rawCards, rawCardStuff) => {
                     monsterId,
                     baseRequirement,
                     thresholds: TIER_MULTIPLIERS.map((multiplier) => (amountRequired += baseRequirement * multiplier)),
-                    amount: toInt(accountCards[monsterId], { min: 0 }),
+                    amount: toInt(accountCards[monsterId] ?? 0, { min: 0 }),
                     path: `${CARD_PATH}.${monsterId}`,
                 };
             })
@@ -206,7 +205,11 @@ const buildCardData = async (rawCards, rawCardStuff) => {
         });
     });
 
-    return { regions, unresolved, total: accountIds.length };
+    return {
+        regions,
+        unresolved,
+        total: regions.reduce((sum, region) => sum + region.cards.length, unresolved.length),
+    };
 };
 
 const CardSection = ({
@@ -280,7 +283,7 @@ const BulkConfirmationModal = ({ pending, status, onCancel, onConfirm }) =>
                 { class: "modal-body cards-bulk-modal__body" },
                 p(() => {
                     if (!pending.val) return "";
-                    return `${pending.val.affectedCount} of ${pending.val.region.cards.length} Account Cards will change.`;
+                    return `${pending.val.affectedCount} of ${pending.val.region.cards.length} cards will change.`;
                 }),
                 p("Each card will be set to its own minimum Card Amount for the selected tier.")
             ),
@@ -410,7 +413,7 @@ export const CardsTab = () => {
     return PersistentAccountListPage({
         title: "CARDS",
         description: () =>
-            `${totalCards.val} Account Cards grouped by Card Region. Edit amounts or set exact tier minimums.`,
+            `${totalCards.val} cards grouped by Card Region. Edit amounts or set exact tier minimums.`,
         actions: RefreshButton({
             onRefresh: load,
             tooltip: "Re-read live cards and definitions from the running game.",

--- a/src/ui/components/views/account/CardsTab.js
+++ b/src/ui/components/views/account/CardsTab.js
@@ -1,0 +1,481 @@
+import van from "../../../vendor/van-1.6.0.js";
+import { Icons } from "../../../assets/icons.js";
+import { gga, readCList, readGgaEntries } from "../../../services/api.js";
+import { toIndexedArray } from "../../../utils/index.js";
+import { EditableNumberRow } from "./EditableNumberRow.js";
+import { useAccountLoad } from "./accountLoadPolicy.js";
+import {
+    cleanName,
+    createStaticRowReconciler,
+    getOrCreateState,
+    joinClasses,
+    resolveNumberInput,
+    resolveValue,
+    runBulkSet,
+    toInt,
+    unwrapH,
+    useWriteStatus,
+    writeVerified,
+} from "./accountShared.js";
+import { RefreshButton } from "./components/AccountPageChrome.js";
+import { ActionButton } from "./components/ActionButton.js";
+import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
+
+const { div, span, button, details, summary, h3, p } = van.tags;
+
+const CARD_PATH = "Cards[0].h";
+const TIER_MULTIPLIERS = [1, 3, 5, 16, 459, 14645];
+const CARD_REGION_NAMES = [
+    "BLUNDER HILLS W1",
+    "YUM-YUM DESERT W2",
+    "EASY RESOURCES",
+    "MEDIUM RESOURCES",
+    "FROSTBITE TUNDRA W3",
+    "HARD RESOURCES",
+    "HYPERION NEBULA W4",
+    "SMOULDERIN PLATEAU W5",
+    "SPIRITED VALLEY W6",
+    "SHIMMERFIN DEEP W7",
+    "DUNGEONS",
+    "BOSSES AND NIGHTMARES",
+    "EVENTS",
+];
+
+const toUnwrappedIndexedArray = (value) => toIndexedArray(unwrapH(value));
+const cardPath = (monsterId) => `${CARD_PATH}.${monsterId}`;
+const tierThresholds = (baseRequirement) => TIER_MULTIPLIERS.map((multiplier) => baseRequirement * multiplier);
+
+const tierIndexForAmount = (amount, thresholds) => {
+    let currentTier = -1;
+    thresholds.forEach((threshold, index) => {
+        if (Number(amount) >= threshold) currentTier = index;
+    });
+    return currentTier;
+};
+
+const nextTierLabel = (amount, thresholds) => {
+    const nextThreshold = thresholds.find((threshold) => Number(amount) < threshold);
+    return nextThreshold === undefined ? "MAX TIER" : `NEXT: ${nextThreshold}`;
+};
+
+const tierBadgeClass = (amount, thresholds) => {
+    const tierIndex = tierIndexForAmount(amount, thresholds);
+    return tierIndex < 0 ? "card-tier-badge--base" : `card-tier-badge--tier-${tierIndex + 1}`;
+};
+
+const TierBadgeContent = ({ amount, thresholds }) => {
+    const tierIndex = tierIndexForAmount(amount, thresholds);
+    if (tierIndex < 0) return span({ class: "card-tier-display" }, "BASE");
+
+    return span(
+        { class: "card-tier-display" },
+        Icons.CardTier(tierIndex + 1, { class: "card-tier-icon" }),
+        `TIER ${tierIndex + 1}`
+    );
+};
+
+const closeOtherTierPickers = (activePicker) => {
+    document.querySelectorAll(".card-tier-picker[open]").forEach((picker) => {
+        if (picker !== activePicker) picker.open = false;
+    });
+};
+
+const TierPicker = ({
+    label = "SET TIER",
+    thresholds = null,
+    onSelect,
+    status = null,
+    disabled = false,
+    className = "",
+    triggerVariant = "apply",
+}) => {
+    const isDisabled = () => Boolean(resolveValue(disabled)) || resolveValue(status) === "loading";
+
+    const picker = details(
+        {
+            class: () => {
+                const resolvedStatus = resolveValue(status);
+                return joinClasses(
+                    "card-tier-picker",
+                    resolveValue(className),
+                    resolvedStatus === "loading" ? "card-tier-picker--loading" : "",
+                    resolvedStatus === "success" ? "card-tier-picker--success" : "",
+                    resolvedStatus === "error" ? "card-tier-picker--error" : ""
+                );
+            },
+            ontoggle: () => {
+                if (picker.open) closeOtherTierPickers(picker);
+            },
+        },
+        summary(
+            {
+                class: `account-btn account-btn--${triggerVariant} card-tier-picker__trigger`,
+                "aria-disabled": () => String(isDisabled()),
+                onclick: (event) => {
+                    if (isDisabled()) event.preventDefault();
+                },
+            },
+            span(label),
+            Icons.ChevronRight({ class: "card-tier-picker__chevron" })
+        ),
+        div(
+            { class: "card-tier-picker__menu" },
+            ...TIER_MULTIPLIERS.map((_, tierIndex) =>
+                button(
+                    {
+                        type: "button",
+                        class: `card-tier-picker__option card-tier-picker__option--tier-${tierIndex + 1}`,
+                        disabled: isDisabled,
+                        onclick: async (event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            picker.open = false;
+                            await onSelect(tierIndex, thresholds?.[tierIndex]);
+                        },
+                    },
+                    Icons.CardTier(tierIndex + 1, { class: "card-tier-icon" }),
+                    span(`TIER ${tierIndex + 1}`),
+                    span({ class: "card-tier-picker__amount" }, thresholds ? String(thresholds[tierIndex]) : "PER CARD")
+                )
+            )
+        )
+    );
+
+    return picker;
+};
+
+const CardRow = ({ card, valueState }) =>
+    EditableNumberRow({
+        valueState,
+        normalize: (rawValue) => resolveNumberInput(rawValue, { min: 0, fallback: null }),
+        write: (nextValue) => writeVerified(card.path, nextValue),
+        renderInfo: () =>
+            div(
+                { class: "account-row__name-group" },
+                span({ class: "account-row__name" }, card.name),
+                span(
+                    { class: "account-row__sub-label" },
+                    () => `${card.monsterId} · ${nextTierLabel(valueState.val, card.thresholds)}`
+                )
+            ),
+        renderBadge: (currentValue) => TierBadgeContent({ amount: currentValue, thresholds: card.thresholds }),
+        renderExtraActions: ({ status, applyValue }) =>
+            TierPicker({
+                thresholds: card.thresholds,
+                status,
+                onSelect: (_, threshold) => applyValue(threshold),
+            }),
+        rowClass: "account-row--wide-controls card-row",
+        badgeClass: () => joinClasses("card-tier-badge", tierBadgeClass(valueState.val, card.thresholds)),
+        controlsClass: "account-row__controls--xl card-row__controls",
+        inputProps: { "aria-label": `Card Amount for ${card.name}` },
+    });
+
+const UnresolvedCardRow = ({ card, valueState }) =>
+    EditableNumberRow({
+        valueState,
+        normalize: (rawValue) => resolveNumberInput(rawValue, { min: 0, fallback: null }),
+        write: (nextValue) => writeVerified(card.path, nextValue),
+        renderInfo: () =>
+            div(
+                { class: "account-row__name-group" },
+                span({ class: "account-row__name" }, card.monsterId),
+                span({ class: "account-row__sub-label" }, "CARD DEFINITION OR NAME UNRESOLVED")
+            ),
+        renderBadge: () => "RAW ONLY",
+        rowClass: "account-row--wide-controls card-row card-row--unresolved",
+        controlsClass: "account-row__controls--xl card-row__controls",
+        inputProps: { "aria-label": `Card Amount for unresolved card ${card.monsterId}` },
+    });
+
+const buildCardData = async (rawCards, rawCardStuff) => {
+    const accountCards = unwrapH(rawCards) ?? {};
+    const accountIds = Object.keys(accountCards);
+    const accountIdSet = new Set(accountIds);
+    const matchedIds = new Set();
+
+    const regions = CARD_REGION_NAMES.map((name, regionIndex) => {
+        const cards = toUnwrappedIndexedArray(toUnwrappedIndexedArray(rawCardStuff)[regionIndex])
+            .map((rawDefinition) => {
+                const definition = toUnwrappedIndexedArray(rawDefinition);
+                const monsterId = String(definition[0] ?? "").trim();
+                if (!monsterId || !accountIdSet.has(monsterId) || matchedIds.has(monsterId)) return null;
+
+                matchedIds.add(monsterId);
+                const baseRequirement = toInt(definition[2], { min: 0 });
+                return {
+                    monsterId,
+                    baseRequirement,
+                    thresholds: tierThresholds(baseRequirement),
+                    amount: toInt(accountCards[monsterId], { min: 0 }),
+                    path: cardPath(monsterId),
+                };
+            })
+            .filter(Boolean);
+
+        return { key: `region-${regionIndex}`, index: regionIndex, name, cards };
+    });
+
+    const monsterIds = regions.flatMap((region) => region.cards.map((card) => card.monsterId));
+    const monsterDefinitions = monsterIds.length
+        ? await readGgaEntries("MonsterDefinitionsGET.h", monsterIds, ["Name"])
+        : {};
+    const unresolved = [];
+
+    regions.forEach((region) => {
+        region.cards = region.cards.filter((card) => {
+            const name = cleanName(monsterDefinitions[card.monsterId]?.Name, "");
+            if (!name) {
+                unresolved.push({ monsterId: card.monsterId, amount: card.amount, path: card.path });
+                return false;
+            }
+
+            card.name = name;
+            return true;
+        });
+    });
+
+    accountIds.forEach((monsterId) => {
+        if (matchedIds.has(monsterId)) return;
+        unresolved.push({
+            monsterId,
+            amount: toInt(accountCards[monsterId], { min: 0 }),
+            path: cardPath(monsterId),
+        });
+    });
+
+    return { regions, unresolved, total: accountIds.length };
+};
+
+const RegionSection = ({ region, openState, valueStates, bulkStatus, activeBulkRegion, requestBulkWrite }) => {
+    const bodyId = `card-region-${region.index}`;
+    const status = () => (activeBulkRegion.val === region.key ? bulkStatus.val : null);
+
+    return div(
+        {
+            class: () =>
+                joinClasses(
+                    "card-region",
+                    openState.val ? "card-region--open" : "",
+                    status() === "success" ? "card-region--success" : "",
+                    status() === "error" ? "card-region--error" : ""
+                ),
+        },
+        div(
+            { class: "card-region__header" },
+            button(
+                {
+                    type: "button",
+                    class: "card-region__toggle",
+                    "aria-expanded": () => String(openState.val),
+                    "aria-controls": bodyId,
+                    onclick: () => (openState.val = !openState.val),
+                },
+                Icons.ChevronRight({ class: "card-region__chevron" }),
+                span({ class: "card-region__title" }, region.name),
+                span({ class: "card-region__count" }, `${region.cards.length} CARDS`)
+            ),
+            TierPicker({
+                label: "SET REGION TIER",
+                status,
+                disabled: () => region.cards.length === 0,
+                className: "card-region__tier-picker",
+                triggerVariant: "max-reset",
+                onSelect: (tierIndex) => requestBulkWrite(region, tierIndex),
+            })
+        ),
+        div(
+            {
+                id: bodyId,
+                class: () => joinClasses("card-region__body account-item-stack", !openState.val ? "is-hidden" : ""),
+            },
+            ...region.cards.map((card) => CardRow({ card, valueState: getOrCreateState(valueStates, card.monsterId) }))
+        )
+    );
+};
+
+const UnresolvedSection = ({ cards, openState, valueStates }) =>
+    div(
+        { class: () => joinClasses("card-region card-region--unresolved", openState.val ? "card-region--open" : "") },
+        div(
+            { class: "card-region__header" },
+            button(
+                {
+                    type: "button",
+                    class: "card-region__toggle",
+                    "aria-expanded": () => String(openState.val),
+                    "aria-controls": "card-region-unresolved",
+                    onclick: () => (openState.val = !openState.val),
+                },
+                Icons.ChevronRight({ class: "card-region__chevron" }),
+                span({ class: "card-region__title" }, "UNRESOLVED CARDS"),
+                span({ class: "card-region__count" }, `${cards.length} CARDS`)
+            )
+        ),
+        div(
+            {
+                id: "card-region-unresolved",
+                class: () => joinClasses("card-region__body account-item-stack", !openState.val ? "is-hidden" : ""),
+            },
+            ...cards.map((card) =>
+                UnresolvedCardRow({ card, valueState: getOrCreateState(valueStates, card.monsterId) })
+            )
+        )
+    );
+
+const BulkConfirmationModal = ({ pending, status, onCancel, onConfirm }) =>
+    div(
+        {
+            class: () => joinClasses("modal cards-bulk-modal", !pending.val ? "is-hidden" : ""),
+            onclick: () => {
+                if (status.val !== "loading") onCancel();
+            },
+        },
+        div(
+            { class: "modal-box cards-bulk-modal__box", onclick: (event) => event.stopPropagation() },
+            div(
+                { class: "modal-header" },
+                h3(() => (pending.val ? `SET ${pending.val.region.name} TO TIER ${pending.val.tierIndex + 1}?` : ""))
+            ),
+            div(
+                { class: "modal-body cards-bulk-modal__body" },
+                p(() => {
+                    if (!pending.val) return "";
+                    return `${pending.val.affectedCount} of ${pending.val.region.cards.length} Account Cards will change.`;
+                }),
+                p("Each card will be set to its own minimum Card Amount for the selected tier.")
+            ),
+            div(
+                { class: "modal-footer" },
+                ActionButton({
+                    label: "CANCEL",
+                    variant: "max-reset",
+                    disabled: () => status.val === "loading",
+                    onClick: onCancel,
+                }),
+                ActionButton({
+                    label: () => (pending.val ? `SET TIER ${pending.val.tierIndex + 1}` : "SET TIER"),
+                    status,
+                    disabled: () => !pending.val || pending.val.affectedCount === 0,
+                    onClick: onConfirm,
+                })
+            )
+        )
+    );
+
+export const CardsTab = () => {
+    const { loading, error, run: runLoad } = useAccountLoad({ label: "Cards" });
+    const { status: bulkStatus, run: runBulk } = useWriteStatus();
+    const totalCards = van.state(0);
+    const amountStates = new Map();
+    const openStates = new Map();
+    const activeBulkRegion = van.state(null);
+    const pendingBulk = van.state(null);
+    const regionsNode = div({ class: "cards-regions" });
+    const reconcileRegions = createStaticRowReconciler(regionsNode);
+
+    const getOpenState = (key) => getOrCreateState(openStates, key, false);
+
+    const requestBulkWrite = (region, tierIndex) => {
+        const affectedCount = region.cards.filter(
+            (card) => getOrCreateState(amountStates, card.monsterId).val !== card.thresholds[tierIndex]
+        ).length;
+        pendingBulk.val = { region, tierIndex, affectedCount };
+    };
+
+    const load = () =>
+        runLoad(async () => {
+            const [rawCards, rawCardStuff] = await Promise.all([gga(CARD_PATH), readCList("CardStuff")]);
+            const data = await buildCardData(rawCards, rawCardStuff);
+            const signature = JSON.stringify({
+                regions: data.regions.map((region) => ({
+                    name: region.name,
+                    cards: region.cards.map((card) => [card.monsterId, card.name, card.baseRequirement]),
+                })),
+                unresolved: data.unresolved.map((card) => card.monsterId),
+            });
+
+            reconcileRegions(signature, () => [
+                ...data.regions.map((region) =>
+                    RegionSection({
+                        region,
+                        openState: getOpenState(region.key),
+                        valueStates: amountStates,
+                        bulkStatus,
+                        activeBulkRegion,
+                        requestBulkWrite,
+                    })
+                ),
+                ...(data.unresolved.length
+                    ? [
+                          UnresolvedSection({
+                              cards: data.unresolved,
+                              openState: getOpenState("unresolved"),
+                              valueStates: amountStates,
+                          }),
+                      ]
+                    : []),
+            ]);
+
+            data.regions.forEach((region) => {
+                region.cards.forEach((card) => (getOrCreateState(amountStates, card.monsterId).val = card.amount));
+            });
+            data.unresolved.forEach((card) => (getOrCreateState(amountStates, card.monsterId).val = card.amount));
+            totalCards.val = data.total;
+        });
+
+    const confirmBulkWrite = async () => {
+        const pending = pendingBulk.val;
+        if (!pending || bulkStatus.val === "loading") return;
+
+        activeBulkRegion.val = pending.region.key;
+        const result = await runBulk(() =>
+            runBulkSet({
+                entries: pending.region.cards,
+                getTargetValue: (card) => card.thresholds[pending.tierIndex],
+                getValueState: (card) => getOrCreateState(amountStates, card.monsterId),
+                getPath: (card) => card.path,
+            })
+        );
+
+        pendingBulk.val = null;
+        if (!result.ok) {
+            getOpenState(pending.region.key).val = true;
+            await load();
+        }
+    };
+
+    load();
+
+    const body = div(
+        { class: "cards-page-content" },
+        div({ class: "scrollable-panel cards-scroll" }, regionsNode),
+        BulkConfirmationModal({
+            pending: pendingBulk,
+            status: bulkStatus,
+            onCancel: () => {
+                if (bulkStatus.val !== "loading") pendingBulk.val = null;
+            },
+            onConfirm: (event) => {
+                event.preventDefault();
+                void confirmBulkWrite();
+            },
+        })
+    );
+
+    return PersistentAccountListPage({
+        title: "CARDS",
+        description: () =>
+            `${totalCards.val} Account Cards grouped by Card Region. Edit amounts or set exact tier minimums.`,
+        actions: RefreshButton({
+            onRefresh: load,
+            tooltip: "Re-read live cards and definitions from the running game.",
+            disabled: () => loading.val || bulkStatus.val === "loading",
+        }),
+        state: { loading, error },
+        loadingText: "READING ACCOUNT CARDS",
+        errorTitle: "CARD READ FAILED",
+        initialWrapperClass: "scrollable-panel",
+        body,
+    });
+};

--- a/src/ui/components/views/account/CardsTab.js
+++ b/src/ui/components/views/account/CardsTab.js
@@ -164,10 +164,11 @@ const buildCardData = async (rawCards, rawCardStuff) => {
 
                 matchedIds.add(monsterId);
                 const baseRequirement = toInt(definition[2], { min: 0 });
+                let amountRequired = 1;
                 return {
                     monsterId,
                     baseRequirement,
-                    thresholds: TIER_MULTIPLIERS.map((multiplier) => baseRequirement * multiplier),
+                    thresholds: TIER_MULTIPLIERS.map((multiplier) => (amountRequired += baseRequirement * multiplier)),
                     amount: toInt(accountCards[monsterId], { min: 0 }),
                     path: `${CARD_PATH}.${monsterId}`,
                 };

--- a/src/ui/entry/style.css
+++ b/src/ui/entry/style.css
@@ -20,6 +20,7 @@
 @import url("../styles/config.css");
 @import url("../styles/_world-tabs.css");
 @import url("../styles/_account-pages.css");
+@import url("../styles/_cards.css");
 @import url("../styles/tabs/w1/_index.css");
 @import url("../styles/tabs/w2/_index.css");
 @import url("../styles/tabs/w3/_index.css");

--- a/src/ui/styles/_cards.css
+++ b/src/ui/styles/_cards.css
@@ -188,17 +188,6 @@
     border-color: var(--c-danger);
 }
 
-.cards-bulk-modal__body {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.cards-bulk-modal__body p {
-    margin: 0;
-    line-height: 1.45;
-}
-
 @media (max-width: 760px) {
     .card-row__controls {
         flex-wrap: wrap;

--- a/src/ui/styles/_cards.css
+++ b/src/ui/styles/_cards.css
@@ -1,0 +1,289 @@
+.cards-page-content {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.cards-scroll {
+    width: 100%;
+}
+
+.cards-regions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.card-region {
+    background: var(--c-panel-dim);
+    border: 1px solid var(--c-border);
+    transition:
+        border-color 0.2s,
+        background 0.2s;
+}
+
+.card-region--success {
+    border-color: var(--c-success);
+    background: color-mix(in srgb, var(--c-success) 8%, var(--c-panel-dim));
+}
+
+.card-region--error {
+    border-color: var(--c-danger);
+    background: color-mix(in srgb, var(--c-danger) 8%, var(--c-panel-dim));
+}
+
+.card-region__header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 46px;
+    padding: 7px 10px;
+}
+
+.card-region__toggle {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    flex: 1;
+    padding: 5px 2px;
+    color: var(--c-text-main);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+}
+
+.card-region__toggle:hover .card-region__title {
+    color: var(--c-accent);
+}
+
+.card-region__chevron {
+    flex-shrink: 0;
+    color: var(--c-text-muted);
+    transition: transform 0.15s;
+}
+
+.card-region--open .card-region__chevron {
+    transform: rotate(90deg);
+}
+
+.card-region__title {
+    overflow: hidden;
+    color: var(--c-text-main);
+    font-size: 0.875rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: color 0.15s;
+}
+
+.card-region__count {
+    margin-left: auto;
+    color: var(--c-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.815rem;
+    white-space: nowrap;
+}
+
+.card-region__body {
+    padding: 8px 10px 10px;
+    border-top: 1px solid var(--c-border);
+}
+
+.card-region--unresolved {
+    border-color: var(--c-danger-40);
+}
+
+.card-row .account-row__badge {
+    --card-tier-color: var(--c-text-muted);
+    display: flex;
+    align-items: center;
+    color: var(--card-tier-color);
+    background: color-mix(in srgb, var(--card-tier-color) 10%, var(--c-panel));
+    border-color: color-mix(in srgb, var(--card-tier-color) 70%, var(--c-border));
+}
+
+.card-tier-display {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.card-tier-icon {
+    width: 1.25em;
+    height: 1.25em;
+    flex-shrink: 0;
+}
+
+.card-tier-badge--base {
+    --card-tier-color: var(--c-text-muted) !important;
+}
+
+.card-tier-badge--tier-1,
+.card-tier-picker__option--tier-1 {
+    --card-tier-color: var(--c-tier-stone);
+}
+
+.card-tier-badge--tier-2,
+.card-tier-picker__option--tier-2 {
+    --card-tier-color: var(--c-tier-gold);
+}
+
+.card-tier-badge--tier-3,
+.card-tier-picker__option--tier-3 {
+    --card-tier-color: var(--c-cauldron-orange);
+}
+
+.card-tier-badge--tier-4,
+.card-tier-picker__option--tier-4 {
+    --card-tier-color: var(--c-tier-zenith);
+}
+
+.card-tier-badge--tier-5,
+.card-tier-picker__option--tier-5 {
+    --card-tier-color: var(--c-ui-red);
+}
+
+.card-tier-badge--tier-6,
+.card-tier-picker__option--tier-6 {
+    --card-tier-color: var(--c-tier-onyx);
+}
+
+.card-row--unresolved .account-row__badge {
+    color: var(--c-danger-soft-text);
+    background: var(--c-danger-10);
+    border-color: var(--c-danger-40);
+}
+
+.card-tier-picker {
+    position: relative;
+    flex-shrink: 0;
+}
+
+.card-tier-picker > summary {
+    list-style: none;
+}
+
+.card-tier-picker > summary::-webkit-details-marker {
+    display: none;
+}
+
+.card-tier-picker__trigger {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 98px;
+    justify-content: center;
+}
+
+.card-tier-picker__trigger[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.card-tier-picker__chevron {
+    transition: transform 0.15s;
+}
+
+.card-tier-picker[open] .card-tier-picker__chevron {
+    transform: rotate(90deg);
+}
+
+.card-tier-picker__menu {
+    position: absolute;
+    z-index: 80;
+    top: calc(100% + 5px);
+    right: 0;
+    display: grid;
+    gap: 3px;
+    width: 220px;
+    padding: 6px;
+    background: var(--c-panel);
+    border: 1px solid var(--c-border-strong);
+    box-shadow: 0 12px 28px var(--c-black-80);
+}
+
+.card-tier-picker__option {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 7px 8px;
+    color: var(--c-text-main);
+    background: var(--c-panel-dim);
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-family: var(--font-display);
+    font-size: 0.875rem;
+    letter-spacing: 0.04em;
+    text-align: left;
+}
+
+.card-tier-picker__option .card-tier-icon {
+    color: var(--card-tier-color);
+}
+
+.card-tier-picker__option:hover {
+    background: var(--c-panel-hover);
+    border-color: var(--card-tier-color);
+}
+
+.card-tier-picker__option:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.card-tier-picker__amount {
+    color: var(--c-text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.815rem;
+}
+
+.card-tier-picker--loading .card-tier-picker__trigger {
+    cursor: wait;
+    opacity: 0.65;
+}
+
+.card-tier-picker--success .card-tier-picker__trigger {
+    color: var(--c-success);
+    border-color: var(--c-success);
+}
+
+.card-tier-picker--error .card-tier-picker__trigger {
+    color: var(--c-danger);
+    border-color: var(--c-danger);
+}
+
+.cards-bulk-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.cards-bulk-modal__body p {
+    margin: 0;
+    line-height: 1.45;
+}
+
+@media (max-width: 760px) {
+    .card-region__header {
+        align-items: stretch;
+        flex-wrap: wrap;
+    }
+
+    .card-region__toggle {
+        flex-basis: 100%;
+    }
+
+    .card-region__tier-picker {
+        margin-left: auto;
+    }
+
+    .card-row__controls {
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+}

--- a/src/ui/styles/_cards.css
+++ b/src/ui/styles/_cards.css
@@ -15,6 +15,7 @@
 }
 
 .card-region {
+    position: relative;
     background: var(--c-panel-dim);
     border: 1px solid var(--c-border);
     transition:
@@ -32,26 +33,25 @@
     background: color-mix(in srgb, var(--c-danger) 8%, var(--c-panel-dim));
 }
 
-.card-region__header {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-height: 46px;
-    padding: 7px 10px;
-}
-
 .card-region__toggle {
     display: flex;
     align-items: center;
     gap: 9px;
+    min-height: 46px;
     min-width: 0;
-    flex: 1;
-    padding: 5px 2px;
+    padding: 7px 150px 7px 12px;
     color: var(--c-text-main);
-    background: transparent;
-    border: none;
     cursor: pointer;
+    list-style: none;
     text-align: left;
+}
+
+.card-region--unresolved .card-region__toggle {
+    padding-right: 12px;
+}
+
+.card-region__toggle::-webkit-details-marker {
+    display: none;
 }
 
 .card-region__toggle:hover .card-region__title {
@@ -64,7 +64,7 @@
     transition: transform 0.15s;
 }
 
-.card-region--open .card-region__chevron {
+.card-region__details[open] .card-region__chevron {
     transform: rotate(90deg);
 }
 
@@ -121,33 +121,27 @@
     --card-tier-color: var(--c-text-muted) !important;
 }
 
-.card-tier-badge--tier-1,
-.card-tier-picker__option--tier-1 {
+.card-tier-badge--tier-1 {
     --card-tier-color: var(--c-tier-stone);
 }
 
-.card-tier-badge--tier-2,
-.card-tier-picker__option--tier-2 {
+.card-tier-badge--tier-2 {
     --card-tier-color: var(--c-tier-gold);
 }
 
-.card-tier-badge--tier-3,
-.card-tier-picker__option--tier-3 {
+.card-tier-badge--tier-3 {
     --card-tier-color: var(--c-cauldron-orange);
 }
 
-.card-tier-badge--tier-4,
-.card-tier-picker__option--tier-4 {
+.card-tier-badge--tier-4 {
     --card-tier-color: var(--c-tier-zenith);
 }
 
-.card-tier-badge--tier-5,
-.card-tier-picker__option--tier-5 {
+.card-tier-badge--tier-5 {
     --card-tier-color: var(--c-ui-red);
 }
 
-.card-tier-badge--tier-6,
-.card-tier-picker__option--tier-6 {
+.card-tier-badge--tier-6 {
     --card-tier-color: var(--c-tier-onyx);
 }
 
@@ -157,102 +151,39 @@
     border-color: var(--c-danger-40);
 }
 
-.card-tier-picker {
-    position: relative;
+.card-tier-select {
+    width: 150px;
+    height: 32px;
     flex-shrink: 0;
-}
-
-.card-tier-picker > summary {
-    list-style: none;
-}
-
-.card-tier-picker > summary::-webkit-details-marker {
-    display: none;
-}
-
-.card-tier-picker__trigger {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-width: 98px;
-    justify-content: center;
-}
-
-.card-tier-picker__trigger[aria-disabled="true"] {
-    cursor: not-allowed;
-    opacity: 0.55;
-}
-
-.card-tier-picker__chevron {
-    transition: transform 0.15s;
-}
-
-.card-tier-picker[open] .card-tier-picker__chevron {
-    transform: rotate(90deg);
-}
-
-.card-tier-picker__menu {
-    position: absolute;
-    z-index: 80;
-    top: calc(100% + 5px);
-    right: 0;
-    display: grid;
-    gap: 3px;
-    width: 220px;
-    padding: 6px;
-    background: var(--c-panel);
-    border: 1px solid var(--c-border-strong);
-    box-shadow: 0 12px 28px var(--c-black-80);
-}
-
-.card-tier-picker__option {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 7px 8px;
-    color: var(--c-text-main);
-    background: var(--c-panel-dim);
-    border: 1px solid transparent;
-    cursor: pointer;
+    padding: 0 6px;
     font-family: var(--font-display);
-    font-size: 0.875rem;
+    font-size: 0.815rem;
+    font-weight: 700;
     letter-spacing: 0.04em;
-    text-align: left;
 }
 
-.card-tier-picker__option .card-tier-icon {
-    color: var(--card-tier-color);
-}
-
-.card-tier-picker__option:hover {
-    background: var(--c-panel-hover);
-    border-color: var(--card-tier-color);
-}
-
-.card-tier-picker__option:disabled {
+.card-tier-select:disabled {
     cursor: not-allowed;
     opacity: 0.55;
 }
 
-.card-tier-picker__amount {
-    color: var(--c-text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.815rem;
+.card-region__tier-select {
+    position: absolute;
+    top: 7px;
+    right: 10px;
 }
 
-.card-tier-picker--loading .card-tier-picker__trigger {
+.card-tier-select--loading {
     cursor: wait;
     opacity: 0.65;
 }
 
-.card-tier-picker--success .card-tier-picker__trigger {
+.card-tier-select--success {
     color: var(--c-success);
     border-color: var(--c-success);
 }
 
-.card-tier-picker--error .card-tier-picker__trigger {
+.card-tier-select--error {
     color: var(--c-danger);
     border-color: var(--c-danger);
 }
@@ -269,19 +200,6 @@
 }
 
 @media (max-width: 760px) {
-    .card-region__header {
-        align-items: stretch;
-        flex-wrap: wrap;
-    }
-
-    .card-region__toggle {
-        flex-basis: 100%;
-    }
-
-    .card-region__tier-picker {
-        margin-left: auto;
-    }
-
     .card-row__controls {
         flex-wrap: wrap;
         justify-content: flex-end;

--- a/src/ui/styles/_cards.css
+++ b/src/ui/styles/_cards.css
@@ -39,7 +39,7 @@
     gap: 9px;
     min-height: 46px;
     min-width: 0;
-    padding: 7px 150px 7px 12px;
+    padding: 7px 170px 7px 12px;
     color: var(--c-text-main);
     cursor: pointer;
     list-style: none;

--- a/src/ui/styles/_world-tabs.css
+++ b/src/ui/styles/_world-tabs.css
@@ -80,6 +80,9 @@
     min-width: 130px;
     font-size: 0.875rem;
 }
+.account-compact-tab-btn {
+    min-width: 80px;
+}
 .world-tab-btn {
     min-width: 64px;
 }


### PR DESCRIPTION
## Summary

- Add an Account > Cards page covering all 13 game-authored card regions.
- Show every non-blank Card Definition, including uncollected cards with an amount of 0.
- Display card tiers, next-tier requirements, internal IDs, and unresolved account entries.
- Support verified individual Card Amount writes and immediate region-wide tier writes.
- Calculate tier minimums cumulatively, including the fixed Tier 0 amount.
- Preserve expanded regions across refreshes and document the new UI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cards page to the Account view.
  * Browse cards by region with expandable sections and tier indicators.
  * Edit card amounts and apply tier thresholds in bulk.
  * View and update unresolved or missing card entries.
  * Added responsive layouts and tier-specific visual styling.

* **Documentation**
  * Documented Account navigation, card behavior, and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->