### PR TITLE
Add wide autoboss toggle

### DIFF
--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -94,13 +94,6 @@ let autobossReload = null;
 let autobossMap = null;
 
 setInterval(() => {
-    if (gga && gga.CurrentMap !== autobossMap) {
-        autobossMap = gga.CurrentMap;
-        autobossArmed = false;
-        clearTimeout(autobossReload);
-        autobossReload = null;
-    }
-
     if (!cheatState.wide.autoboss || !gga || !bossMaps.has(gga.CurrentMap)) {
         autobossArmed = false;
         clearTimeout(autobossReload);
@@ -108,18 +101,28 @@ setInterval(() => {
         return;
     }
 
+    if (gga.CurrentMap !== autobossMap) {
+        autobossMap = gga.CurrentMap;
+        autobossArmed = false;
+        clearTimeout(autobossReload);
+        autobossReload = null;
+    }
+
     if (gga.BossHP > 0) {
         autobossArmed = true;
-    } else if (autobossArmed && !autobossReload) {
-        autobossArmed = false;
-        autobossReload = setTimeout(() => {
-            autobossReload = null;
-            if (!cheatState.wide.autoboss || !bossMaps.has(gga.CurrentMap)) return;
-
-            autobossArmed = false;
-            const fadeOut = behavior.createFadeOut(0.4, 0);
-            const fadeIn = behavior.createFadeIn(0.5, 0);
-            behavior.reloadCurrentScene(fadeOut, fadeIn);
-        }, 1000);
+        return;
     }
+
+    if (!autobossArmed || autobossReload) return;
+
+    autobossArmed = false;
+    autobossReload = setTimeout(() => {
+        autobossReload = null;
+        if (!cheatState.wide.autoboss || !bossMaps.has(gga.CurrentMap)) return;
+
+        autobossArmed = false;
+        const fadeOut = behavior.createFadeOut(0.4, 0);
+        const fadeIn = behavior.createFadeIn(0.5, 0);
+        behavior.reloadCurrentScene(fadeOut, fadeIn);
+    }, 5000);
 }, 1000);

--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -5,12 +5,12 @@
  * - gembuylimit, mtx, post, guild, task, quest, star
  * - giant, gems, plunderous, candy, candytime, nodmg
  * - hidenames, noanim, bigmodel, eventitems, autoloot, perfectobols, autoparty
- * - arcade, eventspins, hoopshop, dartshop, guildpoints, cardcopy, cardpassive
+ * - arcade, eventspins, hoopshop, dartshop, guildpoints, cardcopy, cardpassive, autoboss
  */
 
 import { registerCheats } from "../core/registration.js";
 import { cheatState } from "../core/state.js";
-import { firebase, gga } from "../core/globals.js";
+import { behavior, firebase, gga } from "../core/globals.js";
 import { deepCopy } from "../utils/deepCopy.js";
 import { rollAllObols } from "../helpers/obolRolling.js";
 
@@ -43,6 +43,7 @@ registerCheats({
         { name: "eventspins", message: "Infinite event spins" },
         { name: "hoopshop", message: "hoopshop cost nullify" },
         { name: "dartshop", message: "dartshop cost nullify" },
+        { name: "autoboss", message: "automatically reload defeated boss maps" },
         {
             name: "guildpoints",
             message: "Adds guild points to the guild (max 1200 per week)",
@@ -86,3 +87,39 @@ registerCheats({
         { name: "cardpassive", message: "all cards always give bonus (passive)" },
     ],
 });
+
+const bossMaps = new Set([27, 29, 65, 66, 113, 114, 163, 165, 211, 214, 266]);
+let autobossArmed = false;
+let autobossReload = null;
+let autobossMap = null;
+
+setInterval(() => {
+    if (gga && gga.CurrentMap !== autobossMap) {
+        autobossMap = gga.CurrentMap;
+        autobossArmed = false;
+        clearTimeout(autobossReload);
+        autobossReload = null;
+    }
+
+    if (!cheatState.wide.autoboss || !gga || !bossMaps.has(gga.CurrentMap)) {
+        autobossArmed = false;
+        clearTimeout(autobossReload);
+        autobossReload = null;
+        return;
+    }
+
+    if (gga.BossHP > 0) {
+        autobossArmed = true;
+    } else if (autobossArmed && !autobossReload) {
+        autobossArmed = false;
+        autobossReload = setTimeout(() => {
+            autobossReload = null;
+            if (!cheatState.wide.autoboss || !bossMaps.has(gga.CurrentMap)) return;
+
+            autobossArmed = false;
+            const fadeOut = behavior.createFadeOut(0.4, 0);
+            const fadeIn = behavior.createFadeIn(0.5, 0);
+            behavior.reloadCurrentScene(fadeOut, fadeIn);
+        }, 1000);
+    }
+}, 1000);

--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -88,13 +88,13 @@ registerCheats({
     ],
 });
 
-const bossMaps = new Set([27, 29, 65, 66, 113, 114, 163, 165, 211, 214, 266]);
+const bossMaps = new Set([29, 66, 114, 165, 214, 266]);
 let autobossArmed = false;
 let autobossReload = null;
 let autobossMap = null;
 
 setInterval(() => {
-    if (!cheatState.wide.autoboss || !gga || !bossMaps.has(gga.CurrentMap)) {
+    if (!cheatState.wide.autoboss || !bossMaps.has(gga.CurrentMap)) {
         autobossArmed = false;
         clearTimeout(autobossReload);
         autobossReload = null;


### PR DESCRIPTION
## Summary

- add `wide autoboss` as a persistent toggle for supported boss maps
- arm only after observing positive boss HP and reload once after the boss dies
- wait 5 seconds before reloading so drops can be collected
- cancel pending reloads when Autoboss is disabled or the map changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account-wide **Autoboss** cheat.
  * Automatically reloads defeated boss maps after a short delay, including fade-out and fade-in transitions.
  * Runs conditionally: only when enabled and when the player is on a relevant boss map; cancels pending reloads when conditions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->