### PR TITLE
feat: add live Idleon CDP skill

### DIFF
--- a/.agents/skills/idleon-live-cdp/SKILL.md
+++ b/.agents/skills/idleon-live-cdp/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: idleon-live-cdp
+description: Inspect and interact with a running Legends of Idleon session through the Chrome DevTools Protocol on port 32123. Use when Codex needs to read live game state such as gga.Money, explore gga or Haxe .h structures, query injected Idleon helpers and definitions, diagnose the active game runtime, or make an explicitly requested and verified live-state change.
+---
+
+# Idleon Live CDP
+
+Use the bundled bridge from the Idleon-Injector repository root. Default to read-only work. Treat every evaluated expression as code running inside the live game.
+
+## Start safely
+
+1. Confirm the current directory is the Idleon-Injector repository.
+2. Run the status command before every task. It scans page targets and selects the one where the injected `gga` and `readGamePath` globals are ready.
+3. Inspect the relevant repository code before relying on an unfamiliar game path. Start with `src/cheats/main.js`, then search `src/cheats/` and `src/ui/` for the path or reference.
+4. Read through the injected helper API before using raw JavaScript.
+5. Keep result sets narrow. Read one path or selected map entries instead of serializing all of `gga`, `itemDefs`, or `cList`.
+
+```powershell
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js status
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js read "gga.Money"
+```
+
+Use `--port <number>` only when the configured CDP port differs from 32123.
+
+## Read and discover
+
+Prefer these commands:
+
+```powershell
+# Read a path through the injected path resolver.
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js read "gga.Cards[0].h"
+
+# Read selected definition entries without transferring the full map.
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js entries "gga.MonsterDefinitionsGET.h" "mushG" "Name,MonsterHPTotal"
+
+# Search only named top-level GGA roots.
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js search "100-200" "Money,GemsOwned"
+```
+
+Use `eval` only when the injected helpers cannot answer the question. Keep expressions side-effect-free and return a small plain value.
+
+```powershell
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js eval "({money: gga.Money, map: gga.CurrentMap})"
+```
+
+For advanced references, computed helpers, Haxe traversal, target behavior, and serialization limits, read [references/runtime-surface.md](references/runtime-surface.md).
+
+## Change live state
+
+Change state only when the user explicitly requests that exact mutation. Never infer permission to write from a request to inspect, diagnose, research, or explain.
+
+Before a write:
+
+1. Read and report the current value.
+2. Confirm the path and JSON value match the user's request.
+3. Write one path at a time with `--allow-write`.
+4. Require the bridge's read-back verification to succeed.
+5. Report before, requested, and after values. Stop on a mismatch.
+
+```powershell
+node .agents/skills/idleon-live-cdp/scripts/idleon-cdp.js write "gga.Money" "123" --allow-write
+```
+
+Do not use raw `eval` for a mutation when `writeGamePath` or an existing `cheat(...)` command covers it. Batch writes are non-atomic; avoid them unless the user specifically needs a coordinated batch, and verify every path afterward.
+
+## Guardrails
+
+- Never start, stop, reload, navigate, or attach a different game process unless the user asks.
+- Never call `setup`, `cheat`, `writeGamePath`, `writeGamePaths`, mutating ActorEvents methods, or direct assignments during read-only discovery.
+- Treat `monitorWrap` as a mutation: it replaces a property descriptor. Always pair it with `monitorUnwrap` in the same task.
+- Reconnect and rerun `status` after navigation, character selection, reload, or a lost WebSocket. Runtime object identities can change.
+- Prefer `gga.MonsterDefinitionsGET.h`, `gga.ItemDefinitionsGET.h`, and `gga.CustomLists.h` when freshness matters. Convenience getters can point at an earlier object after the game recreates data.
+- Do not expose unrelated account data. Return only the fields needed for the user's request.
+- Remember that CDP port 32123 has no application-level authentication. Keep all access on loopback.
+
+## Troubleshoot
+
+- Connection refused: the game/browser was not launched with `--remote-debugging-port=32123`, or it has exited.
+- No injected Idleon target: the page exists but cheat injection/setup is not ready; inspect injector logs and `src/modules/game/cheatInjection.js`.
+- `exceptionDetails`: report the full exception description and do not treat the result as valid.
+- `{}` or missing fields: use `readGamePath`, explicitly traverse `.h`, select fields with `entries`, or return a JSON-safe plain object.
+- `null` for special numbers: by-value serialization converts `NaN` and infinities to `null` inside objects and normalizes `-0` to `0`; inspect such values individually when exact numeric identity matters.
+- Missing path: distinguish a resolver error from a valid final property whose value is `undefined`.

--- a/.agents/skills/idleon-live-cdp/agents/openai.yaml
+++ b/.agents/skills/idleon-live-cdp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+    display_name: "Idleon Live CDP"
+    short_description: "Inspect and safely modify live Idleon state"
+    default_prompt: "Use $idleon-live-cdp to inspect the current live Idleon game state through CDP port 32123."

--- a/.agents/skills/idleon-live-cdp/references/runtime-surface.md
+++ b/.agents/skills/idleon-live-cdp/references/runtime-surface.md
@@ -1,0 +1,121 @@
+# Idleon live runtime surface
+
+Read this reference before advanced evaluation, unfamiliar traversal, computed helper calls, monitoring, or any write.
+
+## Source of truth
+
+Re-check these files when the repository changes:
+
+- `src/cheats/main.js`: globals exposed on `window`
+- `src/cheats/core/globals.js`: engine reference initialization
+- `src/cheats/api/stateAccessors.js`: supported path, entry, computed, and write helpers
+- `src/cheats/utils/pathResolver.js`: path grammar and `.h` auto-unwrapping
+- `src/cheats/api/search.js`: search behavior and limits
+- `src/cheats/core/valueMonitor.js`: descriptor-based monitoring
+- `src/modules/game/gameAttachment.js`: port and target discovery
+- `src/modules/game/cheatInjection.js`: injection and game-context expression
+
+## Connection and context
+
+The injector launches Chromium/Electron with `--remote-debugging-port=32123`. `http://127.0.0.1:32123/json/list` may contain the game, DevTools, and unrelated iframe targets. Do not select the first target. Connect to page targets and choose the one where both `typeof gga === "object"` and `typeof readGamePath === "function"` are true.
+
+The injected game context is:
+
+```javascript
+window.__idleon_cheats__ || window.document.querySelector("iframe")?.contentWindow?.__idleon_cheats__;
+```
+
+`window.__idleon_cheats__` is the Haxe/Stencyl application object and is not necessarily `window`. The public getters and helper functions are exposed on the target page's `window` after `setup` completes.
+
+## Public references
+
+| Global           | Meaning                                                            |
+| ---------------- | ------------------------------------------------------------------ |
+| `bEngine`        | `context["com.stencyl.Engine"].engine`                             |
+| `gga`            | Current `bEngine.gameAttributes.h` map                             |
+| `itemDefs`       | Item definition map captured from `gga.ItemDefinitionsGET.h`       |
+| `monsterDefs`    | Monster definition map captured from `gga.MonsterDefinitionsGET.h` |
+| `cList`          | Custom-list map captured from `gga.CustomLists.h`                  |
+| `behavior`       | `context["com.stencyl.behavior.Script"]`                           |
+| `events(number)` | Returns `context["scripts.ActorEvents_<number>"]`                  |
+| `cheats`         | Registered cheat definitions                                       |
+| `cheatState`     | Current cheat toggle/config state                                  |
+
+These are configurable getter properties. The top-level getters are live module bindings, but nested game objects can be recreated. A live probe on 2026-07-12 found `monsterDefs` and `gga.MonsterDefinitionsGET.h` with the same keys but different object identities. Prefer the direct `gga.*.h` path for freshness-sensitive reads and reconnect after character selection or reload.
+
+## Public helper API
+
+| Helper                                          | Behavior                                                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `readGamePath(path)`                            | Resolve a dot/bracket path and return `{ value }` or `{ error }`                           |
+| `readGameEntries(rootPath, keys, fields?)`      | Read selected map entries; field lookup checks `entry.h` first                             |
+| `readComputedValue(namespace, name, args?)`     | Call one allowlisted ActorEvents helper                                                    |
+| `readComputedValues(namespace, name, argSets?)` | Batch the same allowlisted computed helper                                                 |
+| `writeGamePath(path, value)`                    | Assign one JSON-compatible value                                                           |
+| `writeGamePaths(writes)`                        | Assign several paths independently; not atomic                                             |
+| `getGgaKeys()`                                  | Return sorted, non-blacklisted top-level GGA keys                                          |
+| `searchGga(query, keys)`                        | Search selected GGA roots for a string, number, boolean, null, undefined, or numeric range |
+| `monitorWrap(id, path)`                         | Replace a configurable property descriptor and broadcast changes                           |
+| `monitorUnwrap(id)`                             | Restore the descriptor for one monitor id                                                  |
+| `monitorList()`                                 | List active monitor ids and paths                                                          |
+| `cheat(action)`                                 | Dispatch a registered cheat command; potentially mutating                                  |
+
+Computed namespaces currently supported by `stateAccessors.js` are `workbench`, `breeding`, `alchemy`, `summoning`, `atomCollider`, `runCode`, `runCodeType`, `dream`, `skillStats`, `thingies`, `minehead`, and `farming`. Read the map in that file before relying on a method name or argument contract.
+
+## Haxe paths
+
+Haxe objects commonly wrap data in `.h` and may include `__id__`. Examples:
+
+```javascript
+gga.Money;
+gga.Cards[0].h;
+gga.PlayerDATABASE.h[playerName].h;
+gga.CustomLists.h.CardStuff;
+gga.ItemDefinitionsGET.h[itemId].h;
+gga.MonsterDefinitionsGET.h[monsterId].h;
+```
+
+`readGamePath` supports simple dot and bracket segments. It strips `[` and `]`; it is not a full JavaScript parser and does not interpret quoted property names. Use a small, JSON-safe `eval` expression for keys that cannot be represented by this path grammar.
+
+The resolver auto-unwraps `.h` only while walking intermediate segments and only when the next segment is not explicitly `h`. The final returned value is not automatically unwrapped. Therefore `readGamePath("gga.Cards[0]")` returns the wrapper, while `readGamePath("gga.Cards[0].h")` returns its map.
+
+## CDP behavior and limits
+
+- `Runtime.evaluate` can execute arbitrary synchronous or asynchronous JavaScript in the live page. `awaitPromise: true` resolves returned promises.
+- Always check `exceptionDetails`; a protocol response can exist even when the expression threw.
+- Use `returnByValue: true` for disposable plain results. Avoid retaining remote `objectId` handles across reloads.
+- By-value object serialization is lossy for special numbers: `NaN` and infinities become `null`, and `-0` becomes `0`. Functions, symbols, accessors, cycles, and host objects may not serialize usefully.
+- `readGamePath` JSON-round-trips values when possible. This makes Haxe data transferable but has the same JSON losses.
+- A valid final property with value `undefined` can serialize as a missing `value` field. An invalid intermediate segment returns an explicit resolver error.
+- Large reads can stall the game or flood tool output. Prefer `readGameEntries`, selected keys, `Object.keys(...).slice(...)`, counts, and projections.
+- `searchGga` traverses selected roots and reads configurable getters. Narrow the roots and query before running it.
+- Direct assignments and function calls can trigger game side effects, cloud-save behavior, proxy logic, or later overwrites. CDP does not provide transaction or rollback semantics.
+- `writeGamePaths` continues after per-entry failures and does not roll back earlier writes.
+- `monitorWrap` mutates the target descriptor and depends on the injector WebSocket server. Always unwrap it, including after errors.
+- CDP cannot make an uninjected page expose `gga`; injection must have succeeded and `setup` must have registered the globals.
+
+## Safe evaluation patterns
+
+Return projections instead of whole graphs:
+
+```javascript
+({ money: gga.Money, currentMap: gga.CurrentMap });
+```
+
+Inspect structure without invoking methods:
+
+```javascript
+({ type: typeof gga.Cards, keys: Object.keys(gga.Cards ?? {}).slice(0, 20) });
+```
+
+Select definitions through the helper:
+
+```javascript
+readGameEntries("gga.MonsterDefinitionsGET.h", ["mushG"], ["Name", "MonsterHPTotal"]);
+```
+
+Read a computed value only after confirming the namespace and arguments in source:
+
+```javascript
+readComputedValue("workbench", "ExtraMaxLvAtom", [baseMax, index]);
+```

--- a/.agents/skills/idleon-live-cdp/scripts/idleon-cdp.js
+++ b/.agents/skills/idleon-live-cdp/scripts/idleon-cdp.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("node:path");
+const { createRequire } = require("node:module");
+
+function loadCdp() {
+    try {
+        return require("chrome-remote-interface");
+    } catch (originalError) {
+        try {
+            return createRequire(path.join(process.cwd(), "package.json"))("chrome-remote-interface");
+        } catch {
+            throw new Error(
+                `Cannot load chrome-remote-interface. Run this command from the Idleon-Injector repository root. ${originalError.message}`
+            );
+        }
+    }
+}
+
+function usage() {
+    console.log(`Usage:
+  idleon-cdp.js status [--port 32123]
+  idleon-cdp.js read <path> [--port 32123]
+  idleon-cdp.js entries <root-path> <keys> [fields] [--port 32123]
+  idleon-cdp.js search <query> <keys> [--port 32123]
+  idleon-cdp.js eval <expression> [--port 32123]
+  idleon-cdp.js write <path> <value-json> --allow-write [--port 32123]`);
+}
+
+function parseArgs(argv) {
+    const args = [...argv];
+    let port = 32123;
+    let allowWrite = false;
+
+    for (let index = 0; index < args.length; ) {
+        if (args[index] === "--port") {
+            port = Number(args[index + 1]);
+            args.splice(index, 2);
+        } else if (args[index] === "--allow-write") {
+            allowWrite = true;
+            args.splice(index, 1);
+        } else {
+            index += 1;
+        }
+    }
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535)
+        throw new Error("--port must be an integer from 1 to 65535");
+    return { command: args.shift(), args, port, allowWrite };
+}
+
+async function evaluate(client, expression) {
+    const response = await client.Runtime.evaluate({
+        expression,
+        awaitPromise: true,
+        returnByValue: true,
+        allowUnsafeEvalBlockedByCSP: true,
+    });
+
+    if (response.exceptionDetails) {
+        const description = response.exceptionDetails.exception?.description || response.exceptionDetails.text;
+        throw new Error(description || "Runtime.evaluate failed");
+    }
+
+    if (Object.prototype.hasOwnProperty.call(response.result, "value")) return response.result.value;
+    if (response.result.unserializableValue !== undefined) return response.result.unserializableValue;
+    return { type: response.result.type, description: response.result.description };
+}
+
+async function connect(CDP, port) {
+    const targets = await CDP.List({ host: "127.0.0.1", port });
+    const candidates = targets
+        .filter((target) => target.type === "page" && !target.url.startsWith("devtools://"))
+        .sort(
+            (left, right) =>
+                Number(/legendsofidleon\.com/i.test(right.url)) - Number(/legendsofidleon\.com/i.test(left.url))
+        );
+
+    for (const target of candidates) {
+        let client;
+        try {
+            client = await CDP({ host: "127.0.0.1", port, target });
+            const ready = await evaluate(
+                client,
+                `typeof window.gga === "object" && window.gga !== null && typeof window.readGamePath === "function"`
+            );
+            if (ready) return { client, target, targetCount: targets.length };
+        } catch {
+            // Another page target may be the injected game.
+        }
+        if (client) await client.close();
+    }
+
+    throw new Error(`No injected Idleon page target found on 127.0.0.1:${port}`);
+}
+
+function parseJson(value, label) {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        throw new Error(`${label} must be valid JSON: ${error.message}`);
+    }
+}
+
+function parseList(value, label) {
+    try {
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) return parsed;
+    } catch {
+        // PowerShell can strip quotes from JSON arrays passed to native programs.
+    }
+
+    const parsed = value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    if (parsed.length === 0) throw new Error(`${label} must be a comma-separated list or JSON array`);
+    return parsed;
+}
+
+async function runCommand(connection, parsed) {
+    const { client, target, targetCount } = connection;
+    const { command, args, allowWrite } = parsed;
+
+    if (command === "status") {
+        const runtime = await evaluate(
+            client,
+            `({
+                url: location.href,
+                title: document.title,
+                ggaKeys: getGgaKeys().length,
+                gameContextReady: !!window.__idleon_cheats__,
+                references: Object.fromEntries(["bEngine", "gga", "itemDefs", "monsterDefs", "cList", "behavior", "events"].map((key) => [key, typeof window[key]])),
+                helpers: Object.fromEntries(["readGamePath", "readGameEntries", "readComputedValue", "readComputedValues", "writeGamePath", "writeGamePaths", "searchGga", "monitorWrap", "monitorUnwrap"].map((key) => [key, typeof window[key]]))
+            })`
+        );
+        return {
+            port: parsed.port,
+            targetCount,
+            selectedTarget: { id: target.id, type: target.type, url: target.url },
+            runtime,
+        };
+    }
+
+    if (command === "read") {
+        if (args.length !== 1) throw new Error("read requires exactly one path");
+        const result = await evaluate(client, `readGamePath(${JSON.stringify(args[0])})`);
+        if (result?.error) throw new Error(result.error);
+        return { path: args[0], value: result?.value };
+    }
+
+    if (command === "entries") {
+        if (args.length < 2 || args.length > 3)
+            throw new Error("entries requires root-path, keys, and optional fields");
+        const keys = parseList(args[1], "keys");
+        const fields = args.length === 3 ? parseList(args[2], "fields") : null;
+        const result = await evaluate(
+            client,
+            `readGameEntries(${JSON.stringify(args[0])}, ${JSON.stringify(keys)}, ${JSON.stringify(fields)})`
+        );
+        if (result?.error) throw new Error(result.error);
+        return { rootPath: args[0], value: result?.value };
+    }
+
+    if (command === "search") {
+        if (args.length !== 2) throw new Error("search requires a query and keys");
+        const keys = parseList(args[1], "keys");
+        return evaluate(client, `searchGga(${JSON.stringify(args[0])}, ${JSON.stringify(keys)})`);
+    }
+
+    if (command === "eval") {
+        if (args.length === 0) throw new Error("eval requires an expression");
+        return evaluate(client, args.join(" "));
+    }
+
+    if (command === "write") {
+        if (!allowWrite) throw new Error("Refusing to write without --allow-write");
+        if (args.length !== 2) throw new Error("write requires a path and value-json");
+        const value = parseJson(args[1], "value-json");
+        const expression = `(() => {
+            const path = ${JSON.stringify(args[0])};
+            const expected = ${JSON.stringify(value)};
+            const before = readGamePath(path);
+            const write = writeGamePath(path, expected);
+            const after = write.error ? null : readGamePath(path);
+            return {
+                path,
+                before: before.value,
+                expected,
+                write,
+                after: after?.value,
+                verified: !write.error && JSON.stringify(after?.value) === JSON.stringify(expected)
+            };
+        })()`;
+        return evaluate(client, expression);
+    }
+
+    throw new Error(`Unknown command: ${command || "(missing)"}`);
+}
+
+async function main() {
+    const parsed = parseArgs(process.argv.slice(2));
+    if (!parsed.command || parsed.command === "help" || parsed.command === "--help") {
+        usage();
+        return;
+    }
+
+    const CDP = loadCdp();
+    const connection = await connect(CDP, parsed.port);
+    try {
+        const result = await runCommand(connection, parsed);
+        console.log(JSON.stringify(result, null, 2));
+        if (parsed.command === "write" && !result.verified) process.exitCode = 2;
+    } finally {
+        await connection.client.close();
+    }
+}
+
+main().catch((error) => {
+    console.error(error.stack || error.message || error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add a repo-local skill for inspecting an injected Idleon session through CDP port 32123
- add a CLI bridge for status checks, path reads, selected entries, searches, evaluation, and guarded writes
- document the runtime helper surface, Haxe traversal, serialization limits, freshness concerns, and mutation safeguards