### PR TITLE
feat: add toggle for all voting bonuses

### DIFF
--- a/src/cheats/cheats/wide.js
+++ b/src/cheats/cheats/wide.js
@@ -6,6 +6,7 @@
  * - giant, gems, plunderous, candy, candytime, nodmg
  * - hidenames, noanim, bigmodel, eventitems, autoloot, perfectobols, autoparty
  * - arcade, eventspins, hoopshop, dartshop, guildpoints, cardcopy, cardpassive, autoboss
+ * - votebonus
  */
 
 import { registerCheats } from "../core/registration.js";
@@ -85,6 +86,7 @@ registerCheats({
             },
         },
         { name: "cardpassive", message: "all cards always give bonus (passive)" },
+        { name: "votebonus", message: "all Ballot and Meritocracy bonuses active" },
     ],
 });
 

--- a/src/cheats/proxies/events579.js
+++ b/src/cheats/proxies/events579.js
@@ -21,7 +21,7 @@
  */
 
 import { cheatConfig, cheatState } from "../core/state.js";
-import { events, gga } from "../core/globals.js";
+import { cList, events, gga } from "../core/globals.js";
 import { createMethodProxy, createConfigLookupProxy } from "../utils/proxy.js";
 
 /**
@@ -38,6 +38,19 @@ export function setupEvents579Proxies() {
         { state: "w6.sumunit" },
         { state: "w6.grimoire" },
     ]);
+
+    // Summoning2 calculates individual Ballot and Meritocracy bonuses; Summoning supplies their current multiplier.
+    createMethodProxy(ActorEvents579, "_customBlock_Summoning2", function (base, key, bonusIndex) {
+        if (cheatState.wide.votebonus && key === "MeritocBonusz") {
+            const value = Number(cList.NinjaInfo[41][Math.round(1 + 3 * bonusIndex)]);
+            return value * this._customBlock_Summoning("MeritocBonuszMulti", 0, 0);
+        }
+        if (cheatState.wide.votebonus && key === "VotingBonusz") {
+            const value = Number(cList.NinjaInfo[38][Math.round(1 + 3 * bonusIndex)]);
+            return value * this._customBlock_Summoning("VotingBonuszMulti", 0, 0);
+        }
+        return base;
+    });
 
     createConfigLookupProxy(ActorEvents579, "_customBlock_Thingies", [
         { state: "wide.hoopshop" },


### PR DESCRIPTION
## Summary

- add the togglable `wide votebonus` command
- activate all Ballot and Meritocracy bonus calculations while preserving their current multipliers
- leave voting access and progression unchanged
- restore normal calculations when the command is disabled
- document the Vote Bonus Override domain term

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new **Vote Bonus Override** option under Wide Cheats.
  - Enables Ballot and Meritocracy bonuses to apply simultaneously.
  - Preserves existing voting access and unlock behavior.
  - Bonus values now reflect the corresponding in-game progression data when the option is enabled.
- **Documentation**
  - Added guidance describing the Vote Bonus Override and clarifying that it does not modify voting or ballot unlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->