### PR TITLE
Fix infinite All Quick worship loop

### DIFF
--- a/src/cheats/cheats/worlds.js
+++ b/src/cheats/cheats/worlds.js
@@ -72,7 +72,7 @@ registerCheats({
         { name: "book", message: "always max lvl talent book" },
         { name: "prayer", message: "Prayer curse nullification" },
         { name: "worshipspeed", message: "multiply worship charge speed (see config)" },
-        { name: "freeworship", message: "nullification of worship charge cost" },
+        { name: "freeworship", message: "reduce worship charge cost to the minimum" },
         { name: "globalshrines", message: "global shrines" },
         { name: "instantdreams", message: "Dream bar fills instantly" },
         { name: "bettercog", message: "Gives you a bit better cog chances" },

--- a/src/cheats/proxies/clist.js
+++ b/src/cheats/proxies/clist.js
@@ -53,8 +53,8 @@ export function setupCListProxy() {
     // Nullify star sign unlock requirement
     nullifyListCost(cList.SSignInfoUI, 1, 4, "wide.star", "0");
 
-    // Nullify worship cost
-    nullifyListCost(cList.WorshipBASEinfos, 1, 6, "w3.freeworship", "0");
+    // Reduce worship cost to the minimum
+    nullifyListCost(cList.WorshipBASEinfos, 1, 6, "w3.freeworship", "1");
 
     // Gem buy limit (not a simple nullify operation)
     const gembuylimitIndex = 5;


### PR DESCRIPTION
## Summary

- Reduce `w3 freeworship` charge cost from zero to the game's minimum cost.
- Keep All Quick finite while preserving effectively free worship.
- Update the cheat description to match the new behavior.

Fixes #152
Fixes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the worship cost cheat to reduce worship charges to the minimum instead of fully eliminating them.
  * Clarified the description of the worship cost reduction for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->