### PR TITLE
fix: restore wide giant spawns

### DIFF
--- a/src/cheats/proxies/events579.js
+++ b/src/cheats/proxies/events579.js
@@ -40,6 +40,7 @@ export function setupEvents579Proxies() {
     ]);
 
     createConfigLookupProxy(ActorEvents579, "_customBlock_Thingies", [
+        { state: "wide.giant", fixedKey: "GuaranteedCrystalMobs", value: 0 },
         { state: "wide.hoopshop" },
         { state: "wide.dartshop" },
         { state: "w7.zenith" },


### PR DESCRIPTION
The game now checks the guaranteed crystal quota before reaching its giant-spawn logic, which prevents the existing wide giant override from running while that quota remains. This change returns zero for the GuaranteedCrystalMobs lookup only while wide giant is enabled, allowing eligible kills to reach the giant override again. Disabling the cheat immediately restores the game's original quota value.

Fixes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `wide.giant` configuration state, enabling guaranteed crystal mob handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->