### PR TITLE
fix: stabilize trap timer speed after character switches

### DIFF
--- a/src/cheats/proxies/gameAttributes.js
+++ b/src/cheats/proxies/gameAttributes.js
@@ -283,39 +283,6 @@ export function setupGameAttributeProxies() {
         });
     }
 
-    // Trapping (instant trap completion)
-    const playerDatabase = gga.PlayerDATABASE.h;
-    if (!playerDatabase._isPatched) {
-        Object.defineProperty(playerDatabase, "_isPatched", { value: true, enumerable: false });
-
-        for (const name in playerDatabase) {
-            for (const trap of playerDatabase[name].h.PldTraps) {
-                if (!trap) continue;
-
-                let elapsedTime = trap[2];
-
-                Object.defineProperty(trap, 2, {
-                    get() {
-                        return elapsedTime;
-                    },
-                    set(value) {
-                        if (cheatState.w3.trapping) {
-                            if (value <= 0) {
-                                elapsedTime = 0;
-                            } else {
-                                elapsedTime = cheatConfig.w3.trapping(value - elapsedTime) + elapsedTime;
-                            }
-                        } else {
-                            elapsedTime = value;
-                        }
-                    },
-                    enumerable: true,
-                    configurable: true,
-                });
-            }
-        }
-    }
-
     // Alchemy (vial attempts)
     const p2w = gga.CauldronP2W;
     if (!p2w._isPatched) {

--- a/src/cheats/proxies/setup.js
+++ b/src/cheats/proxies/setup.js
@@ -9,6 +9,7 @@
 import { setupBehaviorScriptProxies } from "./behavior.js";
 import { setupFirebaseProxy, setupFirebaseStorageProxy, setupSteamAchievementProxy } from "./firebase.js";
 import { setupGameAttributeProxies } from "./gameAttributes.js";
+import { setupTrappingProxies } from "./trapping.js";
 import { setupCListProxy } from "./clist.js";
 import { setupEvents012Proxies } from "./events012.js";
 import { setupEvents020Proxies } from "./events020.js";
@@ -43,8 +44,11 @@ export function setupAllProxies() {
     setupFirebaseStorageProxy();
     setupSteamAchievementProxy();
 
-    // Game attribute proxies (gems, HP, currencies, cloud save, trapping, alchemy)
+    // Game attribute proxies (gems, HP, currencies, cloud save, alchemy)
     setupGameAttributeProxies();
+
+    // Trapping progress proxies
+    setupTrappingProxies();
 
     // CList proxies (MTX, refinery, vials, prayers)
     setupCListProxy();

--- a/src/cheats/proxies/trapping.js
+++ b/src/cheats/proxies/trapping.js
@@ -1,0 +1,45 @@
+/**
+ * Trapping Proxies
+ *
+ * Multiplies online and away-time trap progress without patching trap arrays,
+ * which the game replaces when traps or characters change.
+ */
+
+import { cheatConfig, cheatState } from "../core/state.js";
+import { events, gga } from "../core/globals.js";
+import { createMethodProxy } from "../utils/proxy.js";
+
+function addTrapProgress(traps, elapsedTime) {
+    for (const trap of traps) {
+        if (trap[2] !== -1) {
+            trap[2] += cheatConfig.w3.trapping(elapsedTime) - elapsedTime;
+        }
+    }
+}
+
+function addAllTrapProgress(elapsedTime) {
+    addTrapProgress(gga.PlacedTraps, elapsedTime);
+
+    for (const name in gga.PlayerDATABASE.h) {
+        addTrapProgress(gga.PlayerDATABASE.h[name].h.PldTraps, elapsedTime);
+    }
+}
+
+/**
+ * Setup online and away-time trapping progress proxies.
+ */
+export function setupTrappingProxies() {
+    const ActorEvents189 = events(189);
+    createMethodProxy(ActorEvents189, "_customBlock_1second", (base) => {
+        if (cheatState.w3.trapping) addAllTrapProgress(1);
+        return base;
+    });
+
+    const ActorEvents266 = events(266);
+    createMethodProxy(ActorEvents266, "_customBlock_AwayTimers", (base, elapsedTime) => {
+        if (cheatState.w3.trapping && elapsedTime > 0 && elapsedTime < 1e8) {
+            addAllTrapProgress(elapsedTime);
+        }
+        return base;
+    });
+}


### PR DESCRIPTION
## Summary

- move trap progress multiplication from replaceable trap data to stable online and away-time hooks
- keep custom trap speed settings working after character switches and trap replacements

Fixes #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trapping acceleration now applies consistently to both active traps and traps stored for players.
  * Trap progress is boosted during regular gameplay and while away, helping eligible traps complete faster.
  * Trap progress remains synchronized without altering the underlying trap data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->