### PR TITLE
fix: lint CDP script as Node.js

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ export default [
         },
     },
     {
-        files: ["src/modules/**/*.js", "src/main.js", "config.js"],
+        files: ["src/modules/**/*.js", "src/main.js", "config.js", ".agents/skills/idleon-live-cdp/scripts/*.js"],
         languageOptions: {
             ecmaVersion: 2022,
             sourceType: "commonjs",


### PR DESCRIPTION
Applies the existing Node/CommonJS ESLint configuration to the Idleon CDP CLI so repository-wide linting no longer treats Node globals as undefined. Fixes the Build and Release workflow failure in run https://github.com/MrJoiny/Idleon-Injector/actions/runs/30009573961.