### PR TITLE
feat: add Permanent Greenstacks viewer

### DIFF
--- a/src/ui/components/views/Account.js
+++ b/src/ui/components/views/Account.js
@@ -11,6 +11,7 @@
 import van from "../../vendor/van-1.6.0.js";
 import { AccountOptionsTab } from "./account/AccountOptionsTab.js";
 import { CardsTab } from "./account/CardsTab.js";
+import { GreenstacksTab } from "./account/GreenstacksTab.js";
 import { TasksTab } from "./account/TasksTab.js";
 import { UpgradeVaultTab } from "./account/UpgradeVaultTab.js";
 import { W1Tab } from "./account/W1Tab.js";
@@ -33,6 +34,7 @@ const ACCOUNT_TABS = [
     { id: "upgrade-vault", label: "UPGRADE VAULT", isWorld: false, component: UpgradeVaultTab },
     { id: "tasks", label: "TASKS", isWorld: false, component: TasksTab },
     { id: "cards", label: "CARDS", isWorld: false, component: CardsTab },
+    { id: "greenstacks", label: "GREENSTACKS", isWorld: false, component: GreenstacksTab },
     { id: "w1", label: "BLUNDER HILLS", isWorld: true, worldNum: 1, component: W1Tab },
     { id: "w2", label: "YUM-YUM DESERT", isWorld: true, worldNum: 2, component: W2Tab },
     { id: "w3", label: "FROSTBITE TUNDRA", isWorld: true, worldNum: 3, component: W3Tab },
@@ -55,7 +57,10 @@ export const Account = () => {
             navClass: "account-sub-nav",
             buttonClass: (tab) => {
                 if (tab.isWorld) return `account-top-tab-btn world-tab-btn w${tab.worldNum}-world-tab`;
-                const compactClass = tab.id === "tasks" || tab.id === "cards" ? "account-compact-tab-btn" : "";
+                const compactClass =
+                    tab.id === "tasks" || tab.id === "cards" || tab.id === "greenstacks"
+                        ? "account-compact-tab-btn"
+                        : "";
                 return `account-top-tab-btn account-options-btn ${compactClass}`;
             },
             renderLabel: (tab) => (tab.isWorld ? span({ class: "world-tab-btn-num" }, `W${tab.worldNum}`) : tab.label),

--- a/src/ui/components/views/account/GreenstacksTab.js
+++ b/src/ui/components/views/account/GreenstacksTab.js
@@ -1,0 +1,166 @@
+import van from "../../../vendor/van-1.6.0.js";
+import { gga, readGgaEntries } from "../../../services/api.js";
+import { toIndexedArray } from "../../../utils/index.js";
+import { SearchBar } from "../../SearchBar.js";
+import { useAccountLoad } from "./accountLoadPolicy.js";
+import { cleanName, largeFormatter } from "./accountShared.js";
+import { RefreshButton } from "./components/AccountPageChrome.js";
+import { AccountRow } from "./components/AccountRow.js";
+import { AccountSection } from "./components/AccountSection.js";
+import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
+
+const { div, span } = van.tags;
+
+const GREENSTACK_AMOUNT = 10_000_000;
+const IGNORED_STORAGE_IDS = new Set(["Blank", "LockedInvSpace"]);
+
+const resolveItemName = (itemId, definitions) => {
+    const definition = definitions[itemId] ?? {};
+    return cleanName(definition.displayName ?? definition.DisplayName ?? definition.Name ?? definition.name, itemId);
+};
+
+const buildPermanentEntries = (rawGreenstacks, definitions) =>
+    toIndexedArray(rawGreenstacks ?? [])
+        .map((rawItemId, index) => ({ itemId: String(rawItemId ?? "").trim(), index }))
+        .filter((entry) => entry.itemId)
+        .map((entry) => ({ ...entry, name: resolveItemName(entry.itemId, definitions) }));
+
+const buildReadyEntries = (rawOrder, rawQuantities, permanentIds, definitions) => {
+    const order = toIndexedArray(rawOrder ?? []);
+    const quantities = toIndexedArray(rawQuantities ?? []);
+    const seen = new Set();
+
+    return order
+        .map((rawItemId, index) => ({
+            itemId: String(rawItemId ?? "").trim(),
+            index,
+            amount: Number(quantities[index] ?? 0),
+        }))
+        .filter((entry) => {
+            if (
+                !entry.itemId ||
+                IGNORED_STORAGE_IDS.has(entry.itemId) ||
+                entry.amount < GREENSTACK_AMOUNT ||
+                permanentIds.has(entry.itemId) ||
+                seen.has(entry.itemId)
+            )
+                return false;
+
+            seen.add(entry.itemId);
+            return true;
+        })
+        .map((entry) => ({ ...entry, name: resolveItemName(entry.itemId, definitions) }));
+};
+
+const GreenstackRow = ({ entry, status }) =>
+    AccountRow({
+        info: [
+            span({ class: "account-row__index" }, `#${entry.index}`),
+            div(
+                { class: "account-row__name-group" },
+                span({ class: "account-row__name" }, entry.name),
+                span(
+                    { class: "account-row__sub-label" },
+                    entry.amount === undefined ? entry.itemId : `${entry.itemId} · ${largeFormatter(entry.amount)}`
+                )
+            ),
+        ],
+        badge: status,
+        badgeClass: status === "PERMANENT" ? "account-row__badge--highlight" : "",
+    });
+
+const matchesSearch = (entry, query) =>
+    !query || entry.name.toLowerCase().includes(query) || entry.itemId.toLowerCase().includes(query);
+
+export const GreenstacksTab = () => {
+    const { loading, error, run } = useAccountLoad({ label: "Permanent Greenstacks" });
+    const permanentEntries = van.state([]);
+    const readyEntries = van.state([]);
+    const searchQuery = van.state("");
+
+    const filteredEntries = (entries) => {
+        const query = searchQuery.val.trim().toLowerCase();
+        return entries.val.filter((entry) => matchesSearch(entry, query));
+    };
+
+    const load = async () =>
+        run(async () => {
+            const [rawGreenstacks, rawOrder, rawQuantities] = await Promise.all([
+                gga("GreenStacks"),
+                gga("ChestOrder"),
+                gga("ChestQuantity"),
+            ]);
+            const greenstacks = toIndexedArray(rawGreenstacks ?? []);
+            const permanentIds = new Set(greenstacks.map((itemId) => String(itemId ?? "").trim()).filter(Boolean));
+            const quantities = toIndexedArray(rawQuantities ?? []);
+            const candidateIds = toIndexedArray(rawOrder ?? [])
+                .map((itemId, index) => ({
+                    itemId: String(itemId ?? "").trim(),
+                    amount: Number(quantities[index] ?? 0),
+                }))
+                .filter(
+                    (entry) =>
+                        entry.itemId &&
+                        !IGNORED_STORAGE_IDS.has(entry.itemId) &&
+                        entry.amount >= GREENSTACK_AMOUNT &&
+                        !permanentIds.has(entry.itemId)
+                )
+                .map((entry) => entry.itemId);
+            const itemIds = [...new Set([...permanentIds, ...candidateIds])];
+            const definitions = itemIds.length
+                ? await readGgaEntries("ItemDefinitionsGET.h", itemIds, ["displayName", "DisplayName", "Name", "name"])
+                : {};
+
+            permanentEntries.val = buildPermanentEntries(greenstacks, definitions);
+            readyEntries.val = buildReadyEntries(rawOrder, rawQuantities, permanentIds, definitions);
+        });
+
+    const renderRows = (entries, status, emptyText) => {
+        const visible = filteredEntries(entries);
+        return visible.length
+            ? div(
+                  { class: "account-item-stack account-item-stack--dense" },
+                  ...visible.map((entry) => GreenstackRow({ entry, status }))
+              )
+            : div({ class: "tab-empty" }, searchQuery.val ? "No Greenstacks match this search." : emptyText);
+    };
+
+    load();
+
+    return PersistentAccountListPage({
+        title: "PERMANENT GREENSTACKS",
+        description:
+            "View permanently registered Greenstacks and storage stacks ready to register. Open storage in-game to register qualifying stacks.",
+        actions: RefreshButton({ onRefresh: load, disabled: () => loading.val }),
+        subNav: div(
+            { class: "control-bar sticky-header" },
+            SearchBar({
+                placeholder: "SEARCH ITEM NAME OR ID",
+                value: searchQuery,
+                onInput: (value) => (searchQuery.val = value),
+            })
+        ),
+        state: { loading, error },
+        loadingText: "READING PERMANENT GREENSTACKS",
+        errorTitle: "PERMANENT GREENSTACKS READ FAILED",
+        initialWrapperClass: "scrollable-panel",
+        body: div(
+            { class: "scrollable-panel content-stack" },
+            AccountSection({
+                title: "PERMANENT",
+                note: () => `${filteredEntries(permanentEntries).length} / ${permanentEntries.val.length} REGISTERED`,
+                body: () =>
+                    renderRows(
+                        permanentEntries,
+                        "PERMANENT",
+                        "No permanent Greenstacks yet. Open storage in-game to register qualifying stacks."
+                    ),
+            }),
+            AccountSection({
+                title: "READY TO REGISTER",
+                note: () => `${filteredEntries(readyEntries).length} / ${readyEntries.val.length} READY`,
+                body: () => renderRows(readyEntries, "READY", "No unregistered ten-million storage stacks found."),
+            })
+        ),
+    });
+};

--- a/src/ui/components/views/account/GreenstacksTab.js
+++ b/src/ui/components/views/account/GreenstacksTab.js
@@ -69,9 +69,6 @@ const GreenstackRow = ({ entry, status }) =>
         badgeClass: status === "PERMANENT" ? "account-row__badge--highlight" : "",
     });
 
-const matchesSearch = (entry, query) =>
-    !query || entry.name.toLowerCase().includes(query) || entry.itemId.toLowerCase().includes(query);
-
 export const GreenstacksTab = () => {
     const { loading, error, run } = useAccountLoad({ label: "Permanent Greenstacks" });
     const permanentEntries = van.state([]);
@@ -80,7 +77,9 @@ export const GreenstacksTab = () => {
 
     const filteredEntries = (entries) => {
         const query = searchQuery.val.trim().toLowerCase();
-        return entries.val.filter((entry) => matchesSearch(entry, query));
+        return entries.val.filter(
+            (entry) => !query || entry.name.toLowerCase().includes(query) || entry.itemId.toLowerCase().includes(query)
+        );
     };
 
     const load = async () =>


### PR DESCRIPTION
Add a searchable, read-only account view for registered Permanent Greenstacks and qualifying storage stacks that are ready to register in-game.