### PR TITLE
feat: expand Button controls

### DIFF
--- a/config.js
+++ b/config.js
@@ -730,6 +730,7 @@ exports.cheatConfig = {
             StaminaCostMulti: (t) => 0,
         },
         minehead: {
+            Button_BonusMULTI: (t) => t * 2, // 2x Button bonuses
             UpgCost: (t) => t / 2, // free upgrades
             DailyTries: (t) => t * 2, // lots of tries
             MaxHP_You: (t) => t * 2, // 2x max health

--- a/src/ui/components/views/account/w7/ButtonTab.js
+++ b/src/ui/components/views/account/w7/ButtonTab.js
@@ -5,15 +5,18 @@ import { useAccountLoad } from "../accountLoadPolicy.js";
 import { RefreshButton } from "../components/AccountPageChrome.js";
 import { AccountSection } from "../components/AccountSection.js";
 import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
-import { writeVerified } from "../accountShared.js";
+import { getOrCreateState, writeVerified } from "../accountShared.js";
 
 const { div } = van.tags;
 
-const BUTTON_FIELD = { index: 594, label: "Presses Done", formatted: true };
+const BUTTON_FIELDS = [
+    { index: 594, label: "Presses Done", formatted: true },
+    { index: 595, label: "Remaining Charges", formatted: true },
+];
 
-const ButtonRow = ({ fieldState, onWrite }) =>
+const ButtonRow = ({ field, fieldState, onWrite }) =>
     ClickerRow({
-        field: BUTTON_FIELD,
+        field,
         fieldState,
         onWrite,
         rowClass: "account-row--wide-controls",
@@ -23,12 +26,17 @@ const ButtonRow = ({ fieldState, onWrite }) =>
 
 export const ButtonTab = () => {
     const { loading, error, run } = useAccountLoad({ label: "Button" });
-    const fieldState = van.state(undefined);
+    const fieldStates = new Map();
 
     const load = async () =>
         run(async () => {
-            const results = await readGgaEntries("OptionsListAccount", [String(BUTTON_FIELD.index)]);
-            fieldState.val = results[String(BUTTON_FIELD.index)] ?? 0;
+            const results = await readGgaEntries(
+                "OptionsListAccount",
+                BUTTON_FIELDS.map((field) => String(field.index))
+            );
+            for (const field of BUTTON_FIELDS) {
+                getOrCreateState(fieldStates, field.index).val = results[String(field.index)] ?? 0;
+            }
         });
 
     const onWrite = async (index, value) => {
@@ -41,8 +49,13 @@ export const ButtonTab = () => {
         { class: "scrollable-panel content-stack" },
         AccountSection({
             title: "BUTTON",
-            note: "OptionsListAccount[594]",
-            body: div({ class: "account-item-stack" }, ButtonRow({ fieldState, onWrite })),
+            note: "OptionsListAccount[594] / [595]",
+            body: div(
+                { class: "account-item-stack" },
+                ...BUTTON_FIELDS.map((field) =>
+                    ButtonRow({ field, fieldState: getOrCreateState(fieldStates, field.index), onWrite })
+                )
+            ),
         })
     );
 
@@ -50,7 +63,7 @@ export const ButtonTab = () => {
 
     return PersistentAccountListPage({
         title: "BUTTON",
-        description: "Set W7 Button presses done from OptionsListAccount[594].",
+        description: "Set W7 Button presses done and remaining charges from OptionsListAccount[594] and [595].",
         actions: RefreshButton({
             onRefresh: load,
             disabled: () => loading.val,

--- a/src/ui/config/configDescriptions.js
+++ b/src/ui/config/configDescriptions.js
@@ -481,6 +481,7 @@ export const configDescriptions = {
     "cheatConfig.w7.spelunkmana.StaminaCostMulti": "Spelunking: No stamina cost in spelunking",
 
     // Minehead
+    "cheatConfig.w7.minehead.Button_BonusMULTI": "The Button: Bonus multiplier",
     "cheatConfig.w7.minehead.UpgCost": "Minehead: Upgrade costs. (lower is better)",
     "cheatConfig.w7.minehead.DailyTries": "Minehead: Daily tries",
     "cheatConfig.w7.minehead.MaxHP_You": "Minehead: Max HP",


### PR DESCRIPTION
Expose remaining Button charges alongside completed presses and add a configurable multiplier for Button bonuses through the existing Minehead proxy.