### PR TITLE
feat: add Hat Rack bonus multiplier

### DIFF
--- a/config.js
+++ b/config.js
@@ -647,6 +647,7 @@ exports.cheatConfig = {
         },
         gallery: {
             GalleryBonusMulti: (t) => t * 2,
+            HatrackBonusMulti: (t) => t * 2,
             InitializeTrophyBonuses: (t) => t,
             InitializeNametagBonuses: (t) => t,
             // PodiumsOwned: (t) => t,

--- a/src/ui/config/configDescriptions.js
+++ b/src/ui/config/configDescriptions.js
@@ -442,6 +442,7 @@ export const configDescriptions = {
 
     // Gallery
     "cheatConfig.w7.gallery.GalleryBonusMulti": "Gallery: All gallery-provided bonuses",
+    "cheatConfig.w7.gallery.HatrackBonusMulti": "Gallery: Premium Hat Rack bonus multiplier",
     "cheatConfig.w7.gallery.InitializeTrophyBonuses": "Gallery: Logic for initializing trophy bonuses",
     "cheatConfig.w7.gallery.InitializeNametagBonuses": "Gallery: Logic for initializing nametag bonuses",
     "cheatConfig.w7.gallery.PodiumsOwned_Lv4": "Gallery: Level 4 podiums owned (max 19)",


### PR DESCRIPTION
Expose the native Hat Rack bonus multiplier through the existing Gallery config proxy and Web UI descriptions.