### PR TITLE
fix: prevent VoteBonus player-select crash

### DIFF
--- a/src/cheats/proxies/events579.js
+++ b/src/cheats/proxies/events579.js
@@ -21,7 +21,7 @@
  */
 
 import { cheatConfig, cheatState } from "../core/state.js";
-import { cList, events, gga } from "../core/globals.js";
+import { behavior, cList, events, gga } from "../core/globals.js";
 import { createMethodProxy, createConfigLookupProxy } from "../utils/proxy.js";
 
 const FOUNTAIN_KEYS = new Set([
@@ -49,6 +49,10 @@ export function setupEvents579Proxies() {
 
     // Summoning2 calculates individual Ballot and Meritocracy bonuses; Summoning supplies their current multiplier.
     createMethodProxy(ActorEvents579, "_customBlock_Summoning2", function (base, key, bonusIndex) {
+        if (cheatState.wide.votebonus) {
+            const sceneName = behavior.getCurrentSceneName();
+            if (sceneName === "GemShop" || sceneName.includes("Tutorial") || sceneName === "PlayerSelect") return base;
+        }
         if (cheatState.wide.votebonus && key === "MeritocBonusz") {
             const value = Number(cList.NinjaInfo[41][Math.round(1 + 3 * bonusIndex)]);
             return value * this._customBlock_Summoning("MeritocBonuszMulti", 0, 0);


### PR DESCRIPTION
## Summary

- Preserve the game's native VoteBonus result in `GemShop`, tutorial scenes, and `PlayerSelect`.
- Keep the existing Ballot and Meritocracy overrides unchanged during gameplay.

## Fix

`wide votebonus` was replacing `_customBlock_Summoning2`'s safe menu result after the base call. The proxy now returns that base result before reading gameplay-only vote-bonus data.