### PR TITLE
feat(w2): add fishing islands controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "idleon-injector-ui",
-    "version": "2.1.1",
+    "version": "2.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "idleon-injector-ui",
-            "version": "2.1.1",
+            "version": "2.4.1",
             "dependencies": {
                 "chrome-remote-interface": "^0.33.0",
                 "enquirer": "^2.3.6",
@@ -602,7 +602,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -849,7 +848,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -1922,8 +1920,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
@@ -2084,7 +2081,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",

--- a/src/ui/components/views/account/W2Tab.js
+++ b/src/ui/components/views/account/W2Tab.js
@@ -11,6 +11,7 @@ import { SigilTab } from "./w2/SigilTab.js";
 import { ArcadeTab } from "./w2/ArcadeTab.js";
 import { PostOfficeTab } from "./w2/PostOfficeTab.js";
 import { KillroyTab } from "./w2/KillroyTab.js";
+import { IslandsTab } from "./w2/IslandsTab.js";
 import { PoppyTab } from "./w2/PoppyTab.js";
 import { createComingSoonPlaceholder, renderLazyPanes, renderTabNav } from "./tabShared.js";
 
@@ -29,6 +30,7 @@ const W2_SUBTABS = [
     { id: "arcade", label: "ARCADE", component: ArcadeTab },
     { id: "post-office", label: "POST OFFICE", component: PostOfficeTab },
     { id: "killroy", label: "KILLROY", component: KillroyTab },
+    { id: "islands", label: "ISLANDS", component: IslandsTab },
     { id: "poppy", label: "POPPY", component: PoppyTab },
 ];
 

--- a/src/ui/components/views/account/w2/IslandsTab.js
+++ b/src/ui/components/views/account/w2/IslandsTab.js
@@ -1,0 +1,286 @@
+/**
+ * W2 - Islands Tab
+ *
+ * Native controls for the Fishing Islands fields in OptionsListAccount.
+ * Island unlocks are stored as a compact token string in [169].
+ */
+
+import van from "../../../../vendor/van-1.6.0.js";
+import { gga, readGgaEntries } from "../../../../services/api.js";
+import { BulkActionBar, SetAllNumberControl } from "../BulkActionBar.js";
+import { SimpleNumberRow } from "../SimpleNumberRow.js";
+import { useAccountLoad } from "../accountLoadPolicy.js";
+import { AccountSection } from "../components/AccountSection.js";
+import { AccountToggleRow } from "../components/AccountToggleRow.js";
+import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
+import {
+    getOrCreateState,
+    resolveNumberInput,
+    runBulkSet,
+    useWriteStatus,
+    writeManyVerified,
+    writeVerified,
+} from "../accountShared.js";
+
+const { div, span } = van.tags;
+
+const UNLOCK_PATH = "OptionsListAccount[169]";
+const ISLANDS = [
+    { token: "_", label: "Trash Island" },
+    { token: "a", label: "Rando Island" },
+    { token: "b", label: "Crystal Island" },
+    { token: "c", label: "Seasalt Island" },
+    { token: "d", label: "Shimmer Island" },
+    { token: "e", label: "Fractal Isle" },
+];
+const CANONICAL_UNLOCK_ORDER = "abcde_";
+
+const CURRENCY_FIELDS = [
+    { index: 161, name: "Garbage Currency" },
+    { index: 162, name: "Bottles Currency" },
+    { index: 170, name: "Uncollected Bottles" },
+];
+const GARBAGE_FIELDS = [
+    { index: 163, name: "% Garbage" },
+    { index: 164, name: "% Bottles" },
+];
+const RANDO_FIELDS = [
+    { index: 166, name: "% Loot" },
+    { index: 167, name: "% Double Boss" },
+];
+const SHIMMER_FIELDS = [
+    { index: 174, name: "Base STR" },
+    { index: 175, name: "Base AGI" },
+    { index: 176, name: "Base WIS" },
+    { index: 177, name: "Base LUK" },
+    { index: 178, name: "% Total Damage" },
+    { index: 179, name: "% Class EXP" },
+    { index: 180, name: "% Skill Efficiency" },
+];
+const ALL_OPTION_INDICES = [
+    ...CURRENCY_FIELDS,
+    ...GARBAGE_FIELDS,
+    ...RANDO_FIELDS,
+    { index: 165 },
+    { index: 169 },
+    { index: 172 },
+    { index: 173 },
+    ...SHIMMER_FIELDS,
+    { index: 184 },
+].map(({ index }) => index);
+
+const canonicalizeUnlocks = (rawValue) => {
+    const raw = String(rawValue ?? "");
+    return [...CANONICAL_UNLOCK_ORDER].filter((token) => raw.includes(token)).join("");
+};
+
+const IslandUnlockRow = ({ island, unlocksState, writeUnlocks }) =>
+    AccountToggleRow({
+        info: div({ class: "account-row__name-group" }, span({ class: "account-row__name" }, island.label)),
+        badge: () => (unlocksState.val.includes(island.token) ? "UNLOCKED" : "LOCKED"),
+        checked: () => unlocksState.val.includes(island.token),
+        title: `Toggle ${island.label}`,
+        write: async (enabled) => {
+            const current = canonicalizeUnlocks(unlocksState.val);
+            const next = canonicalizeUnlocks(enabled ? `${current}${island.token}` : current.replace(island.token, ""));
+            await writeUnlocks(next);
+        },
+    });
+
+const NumericRow = ({ field, valueState, badge }) =>
+    SimpleNumberRow({
+        entry: {
+            ...field,
+            path: `OptionsListAccount[${field.index}]`,
+            min: 0,
+            badge,
+            showIndex: false,
+        },
+        valueState,
+    });
+
+export const IslandsTab = () => {
+    const { loading, error, run: runLoad } = useAccountLoad({ label: "Islands" });
+    const unlockBulk = useWriteStatus();
+    const garbageBulk = useWriteStatus();
+    const randoBulk = useWriteStatus();
+    const shimmerBulk = useWriteStatus();
+    const valueStates = new Map();
+    const unlocksState = van.state("");
+    const bribeState = van.state(0);
+    const garbageSetAll = van.state("200");
+    const randoSetAll = van.state("200");
+    const shimmerSetAll = van.state("200");
+
+    const getValueState = (index) => getOrCreateState(valueStates, index);
+
+    const load = async () =>
+        runLoad(async () => {
+            const values = await readGgaEntries("OptionsListAccount", ALL_OPTION_INDICES.map(String));
+            unlocksState.val = canonicalizeUnlocks(values["169"]);
+            bribeState.val = Number(values["165"] ?? 0) === 1 ? 1 : 0;
+
+            ALL_OPTION_INDICES.filter((index) => ![165, 169].includes(index)).forEach((index) => {
+                getValueState(index).val = Math.max(0, Math.round(Number(values[String(index)] ?? 0) || 0));
+            });
+        });
+
+    const writeUnlocks = async (nextValue, { batch = false } = {}) => {
+        const canonical = canonicalizeUnlocks(nextValue);
+        if (batch) {
+            await writeManyVerified([{ path: UNLOCK_PATH, value: canonical }]);
+        } else {
+            await writeVerified(UNLOCK_PATH, canonical, { write: gga });
+        }
+        unlocksState.val = canonical;
+    };
+
+    const setAll = async (fields, inputState, status) => {
+        const target = resolveNumberInput(inputState.val, { min: 0, fallback: null });
+        if (target === null) return;
+
+        await status.run(() =>
+            runBulkSet({
+                entries: fields,
+                getTargetValue: () => target,
+                getValueState: (field) => getValueState(field.index),
+                getPath: (field) => `OptionsListAccount[${field.index}]`,
+            })
+        );
+    };
+
+    load();
+
+    const content = div(
+        { class: "islands-content scrollable-panel content-stack" },
+        AccountSection({
+            title: "ISLAND UNLOCKS",
+            meta: BulkActionBar({
+                actions: [
+                    {
+                        label: "UNLOCK ALL",
+                        status: unlockBulk.status,
+                        tooltip: "Write the canonical unlock string abcde_",
+                        onClick: () => unlockBulk.run(() => writeUnlocks(CANONICAL_UNLOCK_ORDER, { batch: true })),
+                    },
+                    {
+                        label: "LOCK ALL",
+                        status: unlockBulk.status,
+                        tooltip: "Clear every island unlock",
+                        onClick: () => unlockBulk.run(() => writeUnlocks("", { batch: true })),
+                    },
+                ],
+            }),
+            body: div(
+                { class: "islands-unlock-list" },
+                ...ISLANDS.map((island) => IslandUnlockRow({ island, unlocksState, writeUnlocks }))
+            ),
+        }),
+        AccountSection({
+            title: "CURRENCIES & UNCOLLECTED",
+            body: div(
+                { class: "account-list" },
+                ...CURRENCY_FIELDS.map((field) => NumericRow({ field, valueState: getValueState(field.index) }))
+            ),
+        }),
+        AccountSection({
+            title: "GARBAGE UPGRADES",
+            meta: div(
+                { class: "islands-section__controls" },
+                SetAllNumberControl({
+                    label: "SET ALL",
+                    value: garbageSetAll,
+                    status: garbageBulk.status,
+                    onApply: () => setAll(GARBAGE_FIELDS, garbageSetAll, garbageBulk),
+                })
+            ),
+            body: div(
+                { class: "account-list" },
+                ...GARBAGE_FIELDS.map((field) => NumericRow({ field, valueState: getValueState(field.index) })),
+                AccountToggleRow({
+                    info: div(
+                        { class: "account-row__name-group" },
+                        span({ class: "account-row__name" }, "Emporium Bonus Bribe")
+                    ),
+                    badge: () => (bribeState.val ? "ENABLED" : "DISABLED"),
+                    checked: () => bribeState.val === 1,
+                    title: "Toggle Emporium Bonus Bribe",
+                    write: async (enabled) => {
+                        const next = enabled ? 1 : 0;
+                        await writeVerified("OptionsListAccount[165]", next, { write: gga });
+                        bribeState.val = next;
+                    },
+                })
+            ),
+        }),
+        AccountSection({
+            title: "RANDO UPGRADES",
+            meta: div(
+                { class: "islands-section__controls" },
+                SetAllNumberControl({
+                    label: "SET ALL",
+                    value: randoSetAll,
+                    status: randoBulk.status,
+                    onApply: () => setAll(RANDO_FIELDS, randoSetAll, randoBulk),
+                })
+            ),
+            body: div(
+                { class: "account-list" },
+                ...RANDO_FIELDS.map((field) => NumericRow({ field, valueState: getValueState(field.index) }))
+            ),
+        }),
+        AccountSection({
+            title: "SHIMMER STATUS & UPGRADES",
+            meta: div(
+                { class: "islands-section__controls" },
+                SetAllNumberControl({
+                    label: "SET UPGRADES",
+                    value: shimmerSetAll,
+                    status: shimmerBulk.status,
+                    onApply: () => setAll(SHIMMER_FIELDS, shimmerSetAll, shimmerBulk),
+                })
+            ),
+            body: div(
+                { class: "account-list" },
+                NumericRow({
+                    field: { index: 172, name: "Shimmer Island Dummy DPS" },
+                    valueState: getValueState(172),
+                }),
+                NumericRow({
+                    field: { index: 173, name: "Shimmers Currency" },
+                    valueState: getValueState(173),
+                }),
+                ...SHIMMER_FIELDS.map((field) => NumericRow({ field, valueState: getValueState(field.index) }))
+            ),
+        }),
+        AccountSection({
+            title: "FRACTAL ISLE",
+            body: div(
+                { class: "account-list" },
+                NumericRow({
+                    field: { index: 184, name: "Fractal Isle AFK Time (Hours)" },
+                    valueState: getValueState(184),
+                    badge: (hours) => `${hours ?? 0}h`,
+                })
+            ),
+        })
+    );
+
+    return PersistentAccountListPage({
+        rootClass: "islands-tab tab-container",
+        title: "ISLANDS",
+        description: "Manage Fishing Islands unlocks, currencies, upgrades, and AFK time.",
+        wrapActions: false,
+        actions: BulkActionBar({
+            refresh: {
+                onClick: load,
+                disabled: () => loading.val,
+                tooltip: "Re-read Islands data from game",
+            },
+        }),
+        state: { loading, error },
+        loadingText: "READING ISLANDS",
+        errorTitle: "ISLANDS READ FAILED",
+        body: content,
+    });
+};

--- a/src/ui/styles/tabs/w2/_index.css
+++ b/src/ui/styles/tabs/w2/_index.css
@@ -5,4 +5,5 @@
 @import url("./_arcade.css");
 @import url("./_postoffice.css");
 @import url("./_killroy.css");
+@import url("./_islands.css");
 @import url("./_poppy.css");

--- a/src/ui/styles/tabs/w2/_islands.css
+++ b/src/ui/styles/tabs/w2/_islands.css
@@ -1,0 +1,32 @@
+/* Islands tab */
+.islands-content {
+    overflow: auto;
+    min-height: 0;
+}
+
+.islands-section__controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.islands-section__controls .account-setall-row {
+    min-width: min(100%, 310px);
+}
+
+.islands-unlock-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 5px;
+}
+
+@media (max-width: 620px) {
+    .islands-section__controls {
+        width: 100%;
+    }
+
+    .islands-section__controls .account-setall-row {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- add a World 2 Fishing Islands account tab
- provide editable currencies, upgrades, island unlocks, Emporium bribe state, and Fractal Isle AFK time
- add bulk island unlock and upgrade controls
