### PR TITLE
feat(account): add Masterclasses Grimoire editor

### DIFF
--- a/src/cheats/api/stateAccessors.js
+++ b/src/cheats/api/stateAccessors.js
@@ -184,6 +184,20 @@ export function readComputedMany(namespace, name, argSets = []) {
 }
 
 /**
+ * Delete a game value by dot/bracket path string.
+ * @param {string} path - Path like "gga.DNSM.h.GrimoireTotLV"
+ * @returns {{ ok: true } | { error: string }}
+ */
+export function deletePath(path) {
+    const resolved = resolvePath(path);
+    if (resolved.error) return resolved;
+    const { target, prop } = resolved;
+    if (prop === undefined) return { error: "Path must include at least one key below the root" };
+    if (!delete target[prop]) return { error: `Unable to delete ${path}` };
+    return { ok: true };
+}
+
+/**
  * Write a game value by dot/bracket path string.
  * @param {string} path - Path like "gga.StampLevel[0][3]"
  * @param {any} value - JSON-serializable value to write

--- a/src/cheats/main.js
+++ b/src/cheats/main.js
@@ -24,6 +24,7 @@ import {
     readEntries,
     readComputed,
     readComputedMany,
+    deletePath,
     writePath,
     writePaths,
 } from "./api/stateAccessors.js";
@@ -76,6 +77,7 @@ window.readGamePath = readPath;
 window.readGameEntries = readEntries;
 window.readComputedValue = readComputed;
 window.readComputedValues = readComputedMany;
+window.deleteGamePath = deletePath;
 window.writeGamePath = writePath;
 window.writeGamePaths = writePaths;
 

--- a/src/modules/server/apiRoutes.js
+++ b/src/modules/server/apiRoutes.js
@@ -719,6 +719,39 @@ exports.injectorConfig = ${new_injectorConfig};
         }
     });
 
+    app.post("/api/game/gga/delete", async (req, res) => {
+        const { path } = await req.json();
+        if (!path || typeof path !== "string") {
+            return res.status(400).json({ error: "Missing or invalid path (must be a non-empty string)" });
+        }
+
+        const escaped = path.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+        try {
+            const result = await Runtime.evaluate({
+                expression: `deleteGamePath("${escaped}")`,
+                returnByValue: true,
+                allowUnsafeEvalBlockedByCSP: true,
+            });
+
+            if (result.exceptionDetails) {
+                return res.status(500).json({ error: "Delete failed", details: result.exceptionDetails.text });
+            }
+
+            const data = result.result.value;
+            if (!data || typeof data !== "object") {
+                return res.status(500).json({ error: "Delete returned no data" });
+            }
+            if (data.error) return res.status(500).json({ error: data.error });
+
+            log.debug(`Deleted path: ${path}`);
+            res.json({ ok: true });
+        } catch (err) {
+            log.error("Error in /api/game/gga/delete:", err);
+            res.status(500).json({ error: err.message });
+        }
+    });
+
     app.post("/api/game/gga/write-many", async (req, res) => {
         const { writes } = await req.json();
         if (!Array.isArray(writes) || writes.length === 0) {

--- a/src/ui/components/views/Account.js
+++ b/src/ui/components/views/Account.js
@@ -11,6 +11,7 @@
 import van from "../../vendor/van-1.6.0.js";
 import { AccountOptionsTab } from "./account/AccountOptionsTab.js";
 import { CardsTab } from "./account/CardsTab.js";
+import { MasterclassesTab } from "./account/MasterclassesTab.js";
 import { TasksTab } from "./account/TasksTab.js";
 import { UpgradeVaultTab } from "./account/UpgradeVaultTab.js";
 import { W1Tab } from "./account/W1Tab.js";
@@ -33,6 +34,7 @@ const ACCOUNT_TABS = [
     { id: "upgrade-vault", label: "UPGRADE VAULT", isWorld: false, component: UpgradeVaultTab },
     { id: "tasks", label: "TASKS", isWorld: false, component: TasksTab },
     { id: "cards", label: "CARDS", isWorld: false, component: CardsTab },
+    { id: "masterclasses", label: "MASTERCLASSES", isWorld: false, component: MasterclassesTab },
     { id: "w1", label: "BLUNDER HILLS", isWorld: true, worldNum: 1, component: W1Tab },
     { id: "w2", label: "YUM-YUM DESERT", isWorld: true, worldNum: 2, component: W2Tab },
     { id: "w3", label: "FROSTBITE TUNDRA", isWorld: true, worldNum: 3, component: W3Tab },

--- a/src/ui/components/views/account/MasterclassesTab.js
+++ b/src/ui/components/views/account/MasterclassesTab.js
@@ -1,0 +1,38 @@
+/**
+ * Masterclasses account container.
+ *
+ * New Masterclass systems belong here rather than in the world tabs so their
+ * navigation remains expandable without rearranging account-level navigation.
+ */
+
+import van from "../../../vendor/van-1.6.0.js";
+import { GrimoireTab } from "./masterclasses/GrimoireTab.js";
+import { renderLazyPanes, renderTabNav } from "./tabShared.js";
+
+const { div } = van.tags;
+
+const MASTERCLASSES_SUBTABS = [{ id: "grimoire", label: "GRIMOIRE", component: GrimoireTab }];
+
+export const MasterclassesTab = () => {
+    const activeSubTab = van.state(MASTERCLASSES_SUBTABS[0].id);
+
+    return div(
+        { class: "world-tab masterclasses-tab" },
+        renderTabNav({
+            tabs: MASTERCLASSES_SUBTABS,
+            activeId: activeSubTab,
+            navClass: "world-sub-nav masterclasses-sub-nav",
+            buttonClass: "account-world-sub-tab-btn masterclasses-sub-tab-btn",
+        }),
+        div(
+            { class: "world-sub-content" },
+            ...renderLazyPanes({
+                tabs: MASTERCLASSES_SUBTABS,
+                activeId: activeSubTab,
+                paneClass: "world-sub-pane",
+                dataAttr: "data-subtab",
+                renderContent: (tab) => tab.component(),
+            })
+        )
+    );
+};

--- a/src/ui/components/views/account/masterclasses/GrimoireTab.js
+++ b/src/ui/components/views/account/masterclasses/GrimoireTab.js
@@ -1,0 +1,302 @@
+/**
+ * Deathbringer Grimoire editor.
+ *
+ * Data sources:
+ *   gga.Grimoire                         - current upgrade levels
+ *   gga.CustomLists.h.GrimoireUpg[n][0] - upgrade name
+ *   gga.CustomLists.h.GrimoireUpg[n][4] - defined maximum level
+ *   gga.OptionsListAccount[329]          - total bones collected
+ *   gga.OptionsListAccount[330..333]     - Femur, Ribcage, Cranium, Bovinae
+ *   gga.OptionsListAccount[367]          - Charred Bones AFK toggle
+ */
+
+import van from "../../../../vendor/van-1.6.0.js";
+import { EmptyState } from "../../../EmptyState.js";
+import { SearchBar } from "../../../SearchBar.js";
+import { Icons } from "../../../../assets/icons.js";
+import { deleteGga, gga, readCList, readGgaEntries } from "../../../../services/api.js";
+import { toIndexedArray } from "../../../../utils/index.js";
+import { BulkActionBar } from "../BulkActionBar.js";
+import { useAccountLoad } from "../accountLoadPolicy.js";
+import { ClampedLevelRow } from "../ClampedLevelRow.js";
+import { AccountToggleRow } from "../components/AccountToggleRow.js";
+import { AccountSection } from "../components/AccountSection.js";
+import { InlineEditableNumberField } from "../components/InlineEditableNumberField.js";
+import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
+import {
+    cleanName,
+    getOrCreateState,
+    runBulkSet,
+    toInt,
+    toNum,
+    useWriteStatus,
+    writeVerified,
+} from "../accountShared.js";
+
+const { div, span } = van.tags;
+
+const GRIMOIRE_PATH = "Grimoire";
+const GRIMOIRE_DEFINITIONS_PATH = "GrimoireUpg";
+const GRIMOIRE_TOTAL_LEVEL_CACHE_PATH = "DNSM.h.GrimoireTotLV";
+const AFK_BONES_OPTION = 367;
+
+const BONE_FIELDS = [
+    { key: "femur", optionIndex: 330, name: "FEMUR" },
+    { key: "ribcage", optionIndex: 331, name: "RIBCAGE" },
+    { key: "total", optionIndex: 329, name: "TOTAL BONES COLLECTED" },
+    { key: "cranium", optionIndex: 332, name: "CRANIUM" },
+    { key: "bovinae", optionIndex: 333, name: "BOVINAE" },
+];
+
+const toCurrency = (value) => Math.max(0, toNum(value, 0));
+
+/** Remove unresolved in-game tooltip markers from an upgrade's display name. */
+const cleanGrimoireName = (rawName, index) => {
+    const name = cleanName(rawName, "")
+        .split(/[\u3400-\u9fff(（]/, 1)[0]
+        .trim();
+    return name || `Grimoire Upgrade ${index + 1}`;
+};
+
+/**
+ * Build only editable definitions. The definition table determines the set of
+ * valid upgrades.
+ */
+const buildGrimoireUpgrades = (rawDefinitions) =>
+    toIndexedArray(rawDefinitions ?? [])
+        .map((rawDefinition, index) => {
+            const definition = toIndexedArray(rawDefinition ?? []);
+            const rawName = String(definition[0] ?? "").trim();
+            const maxLevel = toInt(definition[4], { min: 0 });
+            if (!rawName || !maxLevel) return null;
+
+            return {
+                index,
+                name: cleanGrimoireName(rawName, index),
+                maxLevel,
+            };
+        })
+        .filter(Boolean);
+
+const matchesSearch = (upgrade, query) => {
+    const search = String(query ?? "")
+        .trim()
+        .toLowerCase();
+    if (!search) return true;
+
+    return (
+        upgrade.name.toLowerCase().includes(search) ||
+        String(upgrade.index).includes(search) ||
+        `#${upgrade.index}`.includes(search)
+    );
+};
+
+const GrimoireRow = ({ upgrade, levelState }) =>
+    ClampedLevelRow({
+        valueState: levelState,
+        max: upgrade.maxLevel,
+        integerMode: "trunc",
+        maxAction: {
+            label: "MAX",
+            value: upgrade.maxLevel,
+            tooltip: `Set ${upgrade.name} to level ${upgrade.maxLevel}`,
+        },
+        write: async (nextLevel) => {
+            await writeVerified(`${GRIMOIRE_PATH}[${upgrade.index}]`, nextLevel);
+            await deleteGga(GRIMOIRE_TOTAL_LEVEL_CACHE_PATH);
+            return nextLevel;
+        },
+        renderInfo: () => [
+            span({ class: "account-row__index" }, `#${upgrade.index}`),
+            span({ class: "account-row__name" }, upgrade.name),
+        ],
+        renderBadge: (level) => `LV ${level ?? 0} / ${upgrade.maxLevel}`,
+        rowClass: "grimoire-row",
+        badgeClass: "grimoire-row__level",
+        controlsClass: "grimoire-row__controls",
+    });
+
+const BoneCurrencySection = ({ boneStates, afkBonesEnabled }) =>
+    AccountSection({
+        title: "BONE CURRENCY",
+        body: [
+            div(
+                { class: "grimoire-currency__fields" },
+                ...BONE_FIELDS.map((field) =>
+                    InlineEditableNumberField({
+                        label: field.name,
+                        valueState: boneStates.get(field.key),
+                        path: `OptionsListAccount[${field.optionIndex}]`,
+                        rootClass: "grimoire-currency__field",
+                        labelClass: "grimoire-currency__label",
+                        inputClass: "grimoire-currency__set",
+                    })
+                ),
+                AccountToggleRow({
+                    info: div(
+                        { class: "account-row__name-group" },
+                        span({ class: "account-row__name" }, "AFK BONE BONUS")
+                    ),
+                    badge: () => (afkBonesEnabled.val ? "ENABLED" : "DISABLED"),
+                    checked: () => Boolean(afkBonesEnabled.val),
+                    rowClass: "grimoire-currency__toggle",
+                    title: "Enable or disable Charred Bones for AFK Deathbringer.",
+                    write: async (enabled) => {
+                        const nextValue = enabled ? 1 : 0;
+                        await writeVerified(`OptionsListAccount[${AFK_BONES_OPTION}]`, nextValue);
+                        afkBonesEnabled.val = nextValue;
+                    },
+                })
+            ),
+        ],
+    });
+
+export const GrimoireTab = () => {
+    const { loading, error, run: runLoad } = useAccountLoad({ label: "Grimoire" });
+    const { status: bulkStatus, run: runBulk } = useWriteStatus();
+    const upgrades = van.state([]);
+    const searchQuery = van.state("");
+    const boneStates = new Map(BONE_FIELDS.map((field) => [field.key, van.state(0)]));
+    const afkBonesEnabled = van.state(0);
+    const levelStates = new Map();
+    const rowNodes = new Map();
+    const upgradeRows = div({ class: "account-item-stack account-item-stack--dense grimoire-upgrade-list" });
+    const noUpgrades = EmptyState({
+        icon: Icons.SearchX(),
+        title: "NO GRIMOIRE UPGRADES",
+        subtitle: "No valid Grimoire definitions were returned by the running game.",
+    });
+    const upgradeContent = div();
+    let definitionSignature = null;
+
+    const refreshRows = () => {
+        const visibleRows = upgrades.val.filter((upgrade) => matchesSearch(upgrade, searchQuery.val));
+        upgradeRows.replaceChildren(...visibleRows.map((upgrade) => rowNodes.get(upgrade.index)));
+        upgradeContent.replaceChildren(upgrades.val.length ? upgradeRows : noUpgrades);
+    };
+
+    const rebuildRows = (nextUpgrades) => {
+        const nextSignature = nextUpgrades
+            .map((upgrade) => `${upgrade.index}:${upgrade.name}:${upgrade.maxLevel}`)
+            .join("|");
+        if (definitionSignature === nextSignature) return;
+
+        definitionSignature = nextSignature;
+        rowNodes.clear();
+        nextUpgrades.forEach((upgrade) => {
+            rowNodes.set(
+                upgrade.index,
+                GrimoireRow({
+                    upgrade,
+                    levelState: getOrCreateState(levelStates, upgrade.index),
+                })
+            );
+        });
+    };
+
+    van.derive(() => {
+        upgrades.val;
+        searchQuery.val;
+        refreshRows();
+    });
+
+    const load = () =>
+        runLoad(async () => {
+            const optionIndexes = [...BONE_FIELDS.map((field) => String(field.optionIndex)), String(AFK_BONES_OPTION)];
+            const [rawLevels, rawDefinitions, rawOptions] = await Promise.all([
+                gga(GRIMOIRE_PATH),
+                readCList(GRIMOIRE_DEFINITIONS_PATH),
+                readGgaEntries("OptionsListAccount", optionIndexes),
+            ]);
+            const nextUpgrades = buildGrimoireUpgrades(rawDefinitions);
+            const levels = toIndexedArray(rawLevels ?? []);
+
+            rebuildRows(nextUpgrades);
+            nextUpgrades.forEach((upgrade) => {
+                getOrCreateState(levelStates, upgrade.index).val = Math.min(
+                    upgrade.maxLevel,
+                    toInt(levels[upgrade.index], { min: 0 })
+                );
+            });
+
+            BONE_FIELDS.forEach((field) => {
+                boneStates.get(field.key).val = toCurrency(rawOptions?.[String(field.optionIndex)]);
+            });
+            afkBonesEnabled.val = toCurrency(rawOptions?.[String(AFK_BONES_OPTION)]) ? 1 : 0;
+            upgrades.val = nextUpgrades;
+        });
+
+    const runBulkAction = async (mode) => {
+        const currentUpgrades = upgrades.val;
+        if (!currentUpgrades.length || bulkStatus.val === "loading") return;
+
+        const result = await runBulk(async () => {
+            try {
+                await runBulkSet({
+                    entries: currentUpgrades,
+                    getTargetValue: (upgrade) => (mode === "max" ? upgrade.maxLevel : 0),
+                    getValueState: (upgrade) => getOrCreateState(levelStates, upgrade.index),
+                    getPath: (upgrade) => `${GRIMOIRE_PATH}[${upgrade.index}]`,
+                });
+            } finally {
+                await deleteGga(GRIMOIRE_TOTAL_LEVEL_CACHE_PATH);
+            }
+        });
+
+        if (!result.ok) await load();
+    };
+
+    load();
+
+    const body = div(
+        { class: "grimoire-scroll scrollable-panel" },
+        BoneCurrencySection({ boneStates, afkBonesEnabled }),
+        upgradeContent
+    );
+
+    const subNav = div(
+        { class: "control-bar sticky-header grimoire-controls" },
+        SearchBar({
+            placeholder: "SEARCH GRIMOIRE OR INDEX",
+            value: searchQuery,
+            debounceMs: 0,
+            onInput: (value) => (searchQuery.val = value),
+        })
+    );
+
+    return PersistentAccountListPage({
+        title: "GRIMOIRE",
+        description: "Manage Deathbringer Grimoire upgrades and Bone Currency.",
+        wrapActions: false,
+        actions: BulkActionBar({
+            actions: [
+                {
+                    label: "MAX ALL",
+                    status: bulkStatus,
+                    disabled: () => loading.val || bulkStatus.val === "loading",
+                    tooltip: "Set every Grimoire upgrade to its defined maximum level.",
+                    onClick: () => runBulkAction("max"),
+                },
+                {
+                    label: "RESET ALL",
+                    status: bulkStatus,
+                    variant: "danger",
+                    disabled: () => loading.val || bulkStatus.val === "loading",
+                    tooltip: "Reset every Grimoire upgrade to level 0.",
+                    onClick: () => runBulkAction("reset"),
+                },
+            ],
+            refresh: {
+                onClick: load,
+                tooltip: "Re-read Grimoire levels, Bone Currency, and definitions from the running game.",
+                disabled: () => loading.val || bulkStatus.val === "loading",
+            },
+        }),
+        state: { loading, error },
+        subNav,
+        loadingText: "READING GRIMOIRE",
+        errorTitle: "GRIMOIRE READ FAILED",
+        initialWrapperClass: "grimoire-scroll",
+        body,
+    });
+};

--- a/src/ui/entry/style.css
+++ b/src/ui/entry/style.css
@@ -21,6 +21,7 @@
 @import url("../styles/_world-tabs.css");
 @import url("../styles/_account-pages.css");
 @import url("../styles/_cards.css");
+@import url("../styles/_masterclasses.css");
 @import url("../styles/tabs/w1/_index.css");
 @import url("../styles/tabs/w2/_index.css");
 @import url("../styles/tabs/w3/_index.css");

--- a/src/ui/services/api.js
+++ b/src/ui/services/api.js
@@ -280,6 +280,18 @@ export async function gga(path, value) {
     }
 }
 
+/** Delete a cached or derived GGA property by dot/bracket path. */
+export async function deleteGga(path) {
+    const ggaPath = path.startsWith("gga.") ? path : `gga.${path}`;
+    const data = await _request("/game/gga/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path: ggaPath }),
+    });
+
+    if (!data?.ok) throw new Error(`Failed to delete ${ggaPath}`);
+}
+
 /**
  * Write many GGA paths in one backend/CDP round-trip, then verify from the UI
  * using follow-up reads so batch verification matches the single-write gga flow.

--- a/src/ui/styles/_masterclasses.css
+++ b/src/ui/styles/_masterclasses.css
@@ -1,0 +1,98 @@
+/* Masterclasses / Grimoire */
+
+.masterclasses-tab {
+    --world-color: var(--c-accent);
+}
+
+.grimoire-controls {
+    flex-shrink: 0;
+}
+
+.grimoire-scroll {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+}
+
+.grimoire-currency__fields {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.grimoire-currency__field {
+    display: grid;
+    grid-template-columns: 190px auto;
+    justify-content: start;
+    align-items: center;
+    gap: 6px;
+}
+
+.grimoire-currency__label {
+    grid-column: 1 / -1;
+    color: var(--c-text-muted);
+    font-size: 0.815rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+
+.grimoire-currency__field .number-input-wrapper {
+    width: 190px;
+}
+
+.grimoire-currency__set {
+    align-self: end;
+}
+
+.grimoire-currency__toggle {
+    grid-template-columns: max-content max-content;
+    grid-template-areas:
+        "info info"
+        "badge controls";
+    gap: 6px;
+    justify-content: start;
+    padding: 0;
+    border: 0;
+    background: transparent;
+}
+
+.grimoire-currency__toggle .account-row__info {
+    grid-area: info;
+}
+
+.grimoire-currency__toggle .account-row__badge {
+    grid-area: badge;
+    justify-self: start;
+}
+
+.grimoire-currency__toggle .account-row__controls {
+    grid-area: controls;
+    justify-self: start;
+}
+
+.grimoire-upgrade-list {
+    padding-bottom: 4px;
+}
+
+@media (max-width: 980px) {
+    .grimoire-currency__fields {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 760px) {
+    .grimoire-currency__fields {
+        grid-template-columns: 1fr;
+    }
+
+    .grimoire-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .grimoire-row__controls {
+        grid-column: 1 / -1;
+        justify-content: flex-end;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **Account Options → Masterclasses → Grimoire**, including a searchable editor for all defined Grimoire upgrades.
- Adds editable Bone Currency values and the AFK Bone Bonus toggle.
- Adds a safe game-state deletion endpoint used to invalidate the Grimoire total-level cache after level writes.

## Details

- Uses game data for upgrade names and maximum levels, while stripping unresolved tooltip markers.
- Supports per-upgrade **SET** / **MAX** and bulk **MAX ALL** / **RESET ALL** actions.
- Uses the native verified-write flow and re-syncs the editor after a partial bulk-write failure.
- The game stores `gga.DNSM.h.GrimoireTotLV` as a derived, cached total of all Grimoire levels. Writing `gga.Grimoire[index]` alone leaves that old cache in memory, so the in-game Grimoire UI continues to use an incorrect total. After each individual or bulk level write, the new endpoint deletes only that cache key; the game then rebuilds it from the updated upgrade values the next time it is read.