### PR TITLE
feat: add bundle management UI

### DIFF
--- a/src/cheats/helpers/bundles.js
+++ b/src/cheats/helpers/bundles.js
@@ -4,8 +4,12 @@
  * Functions for working with gem shop bundles.
  */
 
-import { gameContext } from "../core/globals.js";
+import { gameContext, gga } from "../core/globals.js";
 import { knownBundles } from "../constants.js";
+
+const getBundleMessages = () => {
+    return gameContext["scripts.CustomMapsREAL"].GemPopupBundleMessages().h || {};
+};
 
 /**
  * Get all available bundles, merging known bundles with game data.
@@ -13,7 +17,7 @@ import { knownBundles } from "../constants.js";
  * @returns {Array<[string, string]>} Array of [displayName, bundleCode] tuples
  */
 export function getAllBundles() {
-    const bundleMessages = gameContext["scripts.CustomMapsREAL"].GemPopupBundleMessages().h || {};
+    const bundleMessages = getBundleMessages();
     const allBundles = [...knownBundles];
 
     for (const [key] of Object.entries(bundleMessages)) {
@@ -24,6 +28,26 @@ export function getAllBundles() {
     }
 
     return allBundles;
+}
+
+/**
+ * Return the current bundle catalog with live ownership flags.
+ *
+ * The page intentionally displays only manually named entries from knownBundles.
+ * Live discovery remains available through getAllBundles() for autocomplete.
+ * Ownership is intentionally read-only here: buying is handled by the existing
+ * game/Firebase cheat flow.
+ *
+ * @returns {Array<{ code: string, name: string, owned: 0 | 1 }>}
+ */
+export function getBundleCatalog() {
+    const bundlesReceived = gga.BundlesReceived.h;
+
+    return knownBundles.map(([name, code]) => ({
+        code,
+        name,
+        owned: Number(bundlesReceived[code]) === 1 ? 1 : 0,
+    }));
 }
 
 /**

--- a/src/cheats/main.js
+++ b/src/cheats/main.js
@@ -29,6 +29,7 @@ import {
 } from "./api/stateAccessors.js";
 import { getAutoCompleteSuggestions } from "./api/suggestions.js";
 import { searchGga, getGgaKeys } from "./api/search.js";
+import { getBundleCatalog } from "./helpers/bundles.js";
 import { monitor } from "./core/valueMonitor.js";
 
 // Sets the config, startup and webport from glob to internal state
@@ -66,6 +67,7 @@ window.updateCheatConfig = updateCheatConfig;
 // WebUI API
 window.getAutoCompleteSuggestions = getAutoCompleteSuggestions;
 window.cheatStateList = getcheatStateList;
+window.getBundleCatalog = getBundleCatalog;
 
 // Search API
 window.searchGga = searchGga;

--- a/src/modules/server/apiRoutes.js
+++ b/src/modules/server/apiRoutes.js
@@ -170,6 +170,33 @@ function setupApiRoutes(app, context, client, config) {
         }
     });
 
+    app.get("/api/game/bundles", async (req, res) => {
+        try {
+            const catalogResult = await Runtime.evaluate({
+                expression: "getBundleCatalog()",
+                awaitPromise: true,
+                returnByValue: true,
+            });
+
+            if (catalogResult.exceptionDetails) {
+                const details =
+                    catalogResult.exceptionDetails.exception?.description ?? catalogResult.exceptionDetails.text;
+                return res.status(500).json({ error: "Failed to read bundle catalog", details });
+            }
+
+            const bundles = catalogResult.result.value;
+            if (!Array.isArray(bundles)) {
+                return res.status(500).json({ error: "Bundle catalog returned invalid data" });
+            }
+
+            log.debug(`Read bundle catalog (${bundles.length} bundles)`);
+            res.json({ bundles });
+        } catch (apiError) {
+            log.error("Error in /api/game/bundles:", apiError);
+            res.status(500).json({ error: "Internal server error while reading bundle catalog" });
+        }
+    });
+
     app.post("/api/toggle", async (req, res) => {
         const { action } = await req.json();
         if (!action) {

--- a/src/ui/components/views/Account.js
+++ b/src/ui/components/views/Account.js
@@ -10,6 +10,7 @@
 
 import van from "../../vendor/van-1.6.0.js";
 import { AccountOptionsTab } from "./account/AccountOptionsTab.js";
+import { BundlesTab } from "./account/BundlesTab.js";
 import { CardsTab } from "./account/CardsTab.js";
 import { TasksTab } from "./account/TasksTab.js";
 import { UpgradeVaultTab } from "./account/UpgradeVaultTab.js";
@@ -33,6 +34,7 @@ const ACCOUNT_TABS = [
     { id: "upgrade-vault", label: "UPGRADE VAULT", isWorld: false, component: UpgradeVaultTab },
     { id: "tasks", label: "TASKS", isWorld: false, component: TasksTab },
     { id: "cards", label: "CARDS", isWorld: false, component: CardsTab },
+    { id: "bundles", label: "BUNDLES", isWorld: false, component: BundlesTab },
     { id: "w1", label: "BLUNDER HILLS", isWorld: true, worldNum: 1, component: W1Tab },
     { id: "w2", label: "YUM-YUM DESERT", isWorld: true, worldNum: 2, component: W2Tab },
     { id: "w3", label: "FROSTBITE TUNDRA", isWorld: true, worldNum: 3, component: W3Tab },
@@ -55,7 +57,7 @@ export const Account = () => {
             navClass: "account-sub-nav",
             buttonClass: (tab) => {
                 if (tab.isWorld) return `account-top-tab-btn world-tab-btn w${tab.worldNum}-world-tab`;
-                const compactClass = tab.id === "tasks" || tab.id === "cards" ? "account-compact-tab-btn" : "";
+                const compactClass = ["tasks", "cards", "bundles"].includes(tab.id) ? "account-compact-tab-btn" : "";
                 return `account-top-tab-btn account-options-btn ${compactClass}`;
             },
             renderLabel: (tab) => (tab.isWorld ? span({ class: "world-tab-btn-num" }, `W${tab.worldNum}`) : tab.label),

--- a/src/ui/components/views/account/BundlesTab.js
+++ b/src/ui/components/views/account/BundlesTab.js
@@ -1,0 +1,485 @@
+import van from "../../../vendor/van-1.6.0.js";
+import { SearchBar } from "../../../components/SearchBar.js";
+import { executeCheatAction, fetchBundleCatalog, gga } from "../../../services/api.js";
+import { useAccountLoad } from "./accountLoadPolicy.js";
+import { AccountRow } from "./components/AccountRow.js";
+import { AccountSection } from "./components/AccountSection.js";
+import { RefreshButton, WarningBanner } from "./components/AccountPageChrome.js";
+import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
+import { createStaticRowReconciler, writeVerified } from "./accountShared.js";
+
+const { div, span, button, h3, p } = van.tags;
+
+const BUNDLES_RECEIVED_PATH = "BundlesReceived.h";
+const BUY_POLL_INTERVAL_MS = 1000;
+const BUY_POLL_ATTEMPTS = 10;
+const BUY_ALL_CONFIRMATION_SECONDS = 5;
+const PLAYER_SELECTION_MESSAGE =
+    "Select a character in-game before buying bundles. Without an active character, bundle items would not be delivered.";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const isOwned = (owned) => Number(owned) === 1;
+const bundlePath = (code) => `${BUNDLES_RECEIVED_PATH}.${code}`;
+
+const matchesSearch = (bundle, query) => {
+    const normalizedQuery = String(query ?? "")
+        .trim()
+        .toLowerCase();
+    return !normalizedQuery || `${bundle.name} ${bundle.code}`.toLowerCase().includes(normalizedQuery);
+};
+
+const BundleRow = ({ bundle, state, searchQuery, buyAllStatus, onBuy, onUnbuy }) =>
+    div(
+        {
+            class: "bundle-row-wrap",
+            hidden: () => !matchesSearch(bundle, searchQuery.val),
+        },
+        AccountRow({
+            status: () => (state.status.val === "success" ? "success" : state.status.val === "error" ? "error" : null),
+            rowClass: "bundle-row",
+            info: div(
+                { class: "account-row__name-group" },
+                span({ class: "account-row__name" }, bundle.name),
+                span({ class: "account-row__sub-label bundle-row__code" }, bundle.code),
+                () =>
+                    state.pending.val
+                        ? span({ class: "bundle-row__pending" }, "WAITING FOR LIVE OWNERSHIP CONFIRMATION")
+                        : null
+            ),
+            badge: () => {
+                if (state.pending.val) return "BUY QUEUED";
+                return isOwned(state.owned.val) ? "OWNED" : "NOT OWNED";
+            },
+            badgeClass: () => {
+                if (state.pending.val) return "bundle-row__badge bundle-row__badge--queued";
+                return isOwned(state.owned.val)
+                    ? "bundle-row__badge bundle-row__badge--owned"
+                    : "bundle-row__badge bundle-row__badge--unowned";
+            },
+            controlsClass: "bundle-row__controls",
+            controls: button(
+                {
+                    type: "button",
+                    class: () =>
+                        isOwned(state.owned.val) ? "btn-danger bundle-row__action" : "btn-primary bundle-row__action",
+                    disabled: () =>
+                        buyAllStatus.val === "loading" || state.pending.val || state.status.val === "loading",
+                    onclick: () => {
+                        if (buyAllStatus.val === "loading" || state.pending.val || state.status.val === "loading")
+                            return;
+                        return isOwned(state.owned.val) ? onUnbuy(bundle, state) : onBuy(bundle, state);
+                    },
+                },
+                () => {
+                    if (state.pending.val) return "BUY QUEUED";
+                    if (state.status.val === "loading") return "UNBUYING";
+                    return isOwned(state.owned.val) ? "UNBUY" : "BUY";
+                }
+            ),
+        })
+    );
+
+const BuyAllConfirmationModal = ({ open, countdown, bundleCount, status, onCancel, onConfirm }) =>
+    div(
+        {
+            class: () => `modal bundles-buy-all-modal ${open.val ? "" : "is-hidden"}`,
+            onclick: () => {
+                if (status.val !== "loading") onCancel();
+            },
+        },
+        div(
+            { class: "modal-box bundles-buy-all-modal__box", onclick: (event) => event.stopPropagation() },
+            div({ class: "modal-header" }, h3("BUY ALL BUNDLES?")),
+            div(
+                { class: "modal-body bundles-buy-all-modal__body" },
+                p(() => `Are you sure you want to buy all ${bundleCount.val} currently unowned bundles?`),
+                p(
+                    { class: "bundles-buy-all-modal__warning" },
+                    "Make sure you have a lot of inventory space for all the items in the bundles."
+                ),
+                p({ class: "bundles-buy-all-modal__countdown" }, () =>
+                    countdown.val > 0
+                        ? `You can confirm in ${countdown.val} second${countdown.val === 1 ? "" : "s"}.`
+                        : "You can now confirm."
+                )
+            ),
+            div(
+                { class: "modal-footer" },
+                button(
+                    {
+                        type: "button",
+                        class: "btn-secondary",
+                        disabled: () => status.val === "loading",
+                        onclick: onCancel,
+                    },
+                    "CANCEL"
+                ),
+                button(
+                    {
+                        type: "button",
+                        class: "btn-primary",
+                        disabled: () => countdown.val > 0 || status.val === "loading" || bundleCount.val === 0,
+                        onclick: onConfirm,
+                    },
+                    () => {
+                        if (status.val === "loading") return "BUYING...";
+                        return countdown.val > 0 ? `OK (${countdown.val})` : "BUY ALL";
+                    }
+                )
+            )
+        )
+    );
+
+export const BundlesTab = () => {
+    const { loading, error, run: runLoad } = useAccountLoad({ label: "Bundles" });
+    const catalogState = van.state([]);
+    const searchQuery = van.state("");
+    const bundleStates = new Map();
+    const purchaseBlockMessage = van.state(null);
+    const buyAllDialogOpen = van.state(false);
+    const buyAllCountdown = van.state(0);
+    const buyAllTargetCount = van.state(0);
+    const buyAllStatus = van.state("idle");
+    const listNode = div({ class: "account-item-stack bundles-list" });
+    const reconcileRows = createStaticRowReconciler(listNode);
+    let catalogCache = [];
+    let buyAllCountdownTimer = null;
+
+    const resetBuyAllStatusAfter = (status, delayMs) => {
+        setTimeout(() => {
+            if (buyAllStatus.val === status) buyAllStatus.val = "idle";
+        }, delayMs);
+    };
+
+    const getBundleState = (code, owned = 0) => {
+        if (!bundleStates.has(code)) {
+            bundleStates.set(code, {
+                owned: van.state(isOwned(owned) ? 1 : 0),
+                pending: van.state(false),
+                status: van.state("idle"),
+                statusResetTimer: null,
+            });
+        }
+        return bundleStates.get(code);
+    };
+
+    const getBuyableBundles = () =>
+        catalogState.val.filter((bundle) => {
+            const state = getBundleState(bundle.code, bundle.owned);
+            return !isOwned(state.owned.val) && !state.pending.val;
+        });
+
+    const buyableCount = van.derive(() => getBuyableBundles().length);
+
+    const clearStatusResetTimer = (state) => {
+        if (state.statusResetTimer !== null) {
+            clearTimeout(state.statusResetTimer);
+            state.statusResetTimer = null;
+        }
+    };
+
+    const resetStatusAfter = (state, delayMs) => {
+        clearStatusResetTimer(state);
+        state.statusResetTimer = setTimeout(() => {
+            state.status.val = "idle";
+            state.statusResetTimer = null;
+        }, delayMs);
+    };
+
+    const markPurchaseSucceeded = (state) => {
+        state.pending.val = false;
+        state.status.val = "success";
+        resetStatusAfter(state, 1200);
+    };
+
+    const markPurchaseFailed = (state) => {
+        state.pending.val = false;
+        state.status.val = "error";
+        resetStatusAfter(state, 1800);
+    };
+
+    const ensurePlayerSelected = async () => {
+        try {
+            const player = await gga("UserInfo[0]");
+            if (player !== null && player !== undefined) {
+                purchaseBlockMessage.val = null;
+                return true;
+            }
+        } catch (caughtError) {
+            console.error("[bundles] Active character check failed:", caughtError);
+            purchaseBlockMessage.val = "Could not verify the selected character. Select a character and try again.";
+            return false;
+        }
+
+        purchaseBlockMessage.val = PLAYER_SELECTION_MESSAGE;
+        return false;
+    };
+
+    const clearBuyAllCountdown = () => {
+        if (buyAllCountdownTimer !== null) {
+            clearInterval(buyAllCountdownTimer);
+            buyAllCountdownTimer = null;
+        }
+    };
+
+    const closeBuyAllDialog = () => {
+        clearBuyAllCountdown();
+        buyAllDialogOpen.val = false;
+        buyAllCountdown.val = 0;
+    };
+
+    const openBuyAllDialog = async () => {
+        if (buyAllStatus.val === "loading" || buyableCount.val === 0) return;
+        if (!(await ensurePlayerSelected())) return;
+
+        clearBuyAllCountdown();
+        buyAllTargetCount.val = buyableCount.val;
+        buyAllCountdown.val = BUY_ALL_CONFIRMATION_SECONDS;
+        buyAllDialogOpen.val = true;
+        buyAllCountdownTimer = setInterval(() => {
+            buyAllCountdown.val = Math.max(0, buyAllCountdown.val - 1);
+            if (buyAllCountdown.val === 0) clearBuyAllCountdown();
+        }, 1000);
+    };
+
+    const totals = van.derive(() => {
+        const bundles = catalogState.val;
+        const owned = bundles.filter((bundle) => isOwned(getBundleState(bundle.code).owned.val)).length;
+        const queued = bundles.filter((bundle) => getBundleState(bundle.code).pending.val).length;
+        return { total: bundles.length, owned, queued };
+    });
+
+    const applyCatalog = (catalog) => {
+        catalogCache = [...catalog].sort((a, b) => a.name.localeCompare(b.name) || a.code.localeCompare(b.code));
+        catalogState.val = catalogCache;
+
+        for (const bundle of catalogCache) {
+            const state = getBundleState(bundle.code, bundle.owned);
+            state.owned.val = bundle.owned;
+            if (bundle.owned === 1) state.pending.val = false;
+        }
+
+        reconcileRows(catalogCache.map((bundle) => `${bundle.code}:${bundle.name}`).join("|"), () =>
+            catalogCache.map((bundle) =>
+                BundleRow({
+                    bundle,
+                    state: getBundleState(bundle.code, bundle.owned),
+                    searchQuery,
+                    buyAllStatus,
+                    onBuy: buyBundle,
+                    onUnbuy: unbuyBundle,
+                })
+            )
+        );
+    };
+
+    const refreshCatalog = async () => {
+        applyCatalog(await fetchBundleCatalog());
+        return catalogCache;
+    };
+
+    const pollForOwnership = async (code, state) => {
+        for (let attempt = 0; attempt < BUY_POLL_ATTEMPTS; attempt += 1) {
+            await delay(BUY_POLL_INTERVAL_MS);
+            await refreshCatalog();
+            if (isOwned(state.owned.val)) return true;
+        }
+        return false;
+    };
+
+    const pollForOwnershipBatch = async (entries) => {
+        const pendingEntries = new Map(entries.map(({ bundle, state }) => [bundle.code, state]));
+
+        for (let attempt = 0; attempt < BUY_POLL_ATTEMPTS && pendingEntries.size; attempt += 1) {
+            await delay(BUY_POLL_INTERVAL_MS);
+            await refreshCatalog();
+
+            for (const [code, state] of pendingEntries) {
+                if (!isOwned(state.owned.val)) continue;
+                markPurchaseSucceeded(state);
+                pendingEntries.delete(code);
+            }
+        }
+
+        return pendingEntries;
+    };
+
+    const queueBundleBuy = async (bundle, state) => {
+        clearStatusResetTimer(state);
+        state.pending.val = true;
+        state.status.val = "idle";
+
+        try {
+            await executeCheatAction(`buy ${bundle.code}`);
+            return true;
+        } catch (caughtError) {
+            console.error(`[bundles] Buy failed for ${bundle.code}:`, caughtError);
+            markPurchaseFailed(state);
+            return false;
+        }
+    };
+
+    async function buyBundle(bundle, state) {
+        if (buyAllStatus.val === "loading" || isOwned(state.owned.val) || state.pending.val) return;
+        if (!(await ensurePlayerSelected())) {
+            markPurchaseFailed(state);
+            return;
+        }
+
+        if (!(await queueBundleBuy(bundle, state))) return;
+
+        try {
+            const confirmed = await pollForOwnership(bundle.code, state);
+            if (confirmed) {
+                markPurchaseSucceeded(state);
+            } else {
+                markPurchaseFailed(state);
+            }
+        } catch (caughtError) {
+            console.error(`[bundles] Ownership poll failed for ${bundle.code}:`, caughtError);
+            markPurchaseFailed(state);
+        }
+    }
+
+    async function buyAllBundles() {
+        if (buyAllCountdown.val > 0 || buyAllStatus.val === "loading") return;
+        buyAllStatus.val = "loading";
+        if (!(await ensurePlayerSelected())) {
+            closeBuyAllDialog();
+            buyAllStatus.val = "error";
+            resetBuyAllStatusAfter("error", 1800);
+            return;
+        }
+
+        const bundles = getBuyableBundles();
+        closeBuyAllDialog();
+        if (!bundles.length) {
+            buyAllStatus.val = "idle";
+            return;
+        }
+
+        const queued = [];
+        let queueRequestFailed = false;
+
+        for (const bundle of bundles) {
+            const state = getBundleState(bundle.code, bundle.owned);
+            if (await queueBundleBuy(bundle, state)) queued.push({ bundle, state });
+            else queueRequestFailed = true;
+        }
+
+        if (!queued.length) {
+            buyAllStatus.val = "error";
+            resetBuyAllStatusAfter("error", 1800);
+            return;
+        }
+
+        try {
+            const pending = await pollForOwnershipBatch(queued);
+            for (const state of pending.values()) markPurchaseFailed(state);
+
+            const completed = !queueRequestFailed && pending.size === 0;
+            buyAllStatus.val = completed ? "success" : "error";
+            resetBuyAllStatusAfter(completed ? "success" : "error", completed ? 1200 : 1800);
+        } catch (caughtError) {
+            console.error("[bundles] Ownership poll failed after Buy All:", caughtError);
+            for (const { state } of queued) {
+                if (!isOwned(state.owned.val)) markPurchaseFailed(state);
+            }
+            buyAllStatus.val = "error";
+            resetBuyAllStatusAfter("error", 1800);
+        }
+    }
+
+    async function unbuyBundle(bundle, state) {
+        if (buyAllStatus.val === "loading" || !isOwned(state.owned.val) || state.pending.val) return;
+
+        clearStatusResetTimer(state);
+        state.status.val = "loading";
+        try {
+            // Unbuy is deliberately the only direct ownership write, and it can
+            // only write 0. writeVerified reads the flag back before this updates.
+            await writeVerified(bundlePath(bundle.code), 0);
+            state.owned.val = 0;
+            state.pending.val = false;
+            state.status.val = "success";
+            resetStatusAfter(state, 1200);
+        } catch (caughtError) {
+            console.error(`[bundles] Unbuy failed for ${bundle.code}:`, caughtError);
+            markPurchaseFailed(state);
+        }
+    }
+
+    const load = () => runLoad(refreshCatalog);
+    load();
+
+    const playerSelectionWarning = div(
+        { hidden: () => !purchaseBlockMessage.val },
+        WarningBanner(() => purchaseBlockMessage.val)
+    );
+
+    const body = div(
+        { class: "scrollable-panel content-stack bundles-scroll" },
+        div(
+            { class: "bundles-search" },
+            SearchBar({
+                placeholder: "SEARCH BUNDLES OR CODES",
+                value: searchQuery,
+                debounceMs: 0,
+                onInput: (value) => (searchQuery.val = value),
+            })
+        ),
+        AccountSection({
+            title: "BUNDLE CATALOG",
+            note: () => {
+                const value = totals.val;
+                const queueLabel = value.queued ? `, ${value.queued} QUEUED` : "";
+                return `${value.total} BUNDLES, ${value.owned} OWNED, ${value.total - value.owned} NOT OWNED${queueLabel}`;
+            },
+            body: () =>
+                catalogState.val.length
+                    ? listNode
+                    : div({ class: "tab-empty" }, "No bundle codes were returned by the running game."),
+        }),
+        BuyAllConfirmationModal({
+            open: buyAllDialogOpen,
+            countdown: buyAllCountdown,
+            bundleCount: buyAllTargetCount,
+            status: buyAllStatus,
+            onCancel: closeBuyAllDialog,
+            onConfirm: buyAllBundles,
+        })
+    );
+
+    return PersistentAccountListPage({
+        title: "BUNDLES",
+        description:
+            "Buy bundles and see which ones your account has received. Unbuy lets you mark a bundle as not received again, but does not remove its items from the Slab.",
+        actions: [
+            button(
+                {
+                    type: "button",
+                    class: "btn-primary bundles-buy-all-button",
+                    disabled: () =>
+                        loading.val || buyAllDialogOpen.val || buyAllStatus.val === "loading" || buyableCount.val === 0,
+                    onclick: openBuyAllDialog,
+                },
+                () => {
+                    if (buyAllStatus.val === "loading") return "BUYING ALL...";
+                    if (buyAllStatus.val === "error") return "BUY ALL FAILED";
+                    return `BUY ALL (${buyableCount.val})`;
+                }
+            ),
+            RefreshButton({
+                onRefresh: load,
+                tooltip: "Re-read bundle names, codes, and ownership from the running game.",
+                disabled: () => loading.val || buyAllStatus.val === "loading",
+            }),
+        ],
+        topNotices: [WarningBanner("Bundles do not provide gems or pets."), playerSelectionWarning],
+        state: { loading, error },
+        loadingText: "READING BUNDLES",
+        errorTitle: "BUNDLE READ FAILED",
+        initialWrapperClass: "scrollable-panel",
+        body,
+    });
+};

--- a/src/ui/components/views/account/BundlesTab.js
+++ b/src/ui/components/views/account/BundlesTab.js
@@ -6,7 +6,7 @@ import { AccountRow } from "./components/AccountRow.js";
 import { AccountSection } from "./components/AccountSection.js";
 import { RefreshButton, WarningBanner } from "./components/AccountPageChrome.js";
 import { PersistentAccountListPage } from "./components/PersistentAccountListPage.js";
-import { createStaticRowReconciler, writeVerified } from "./accountShared.js";
+import { createStaticRowReconciler, useWriteStatus, writeVerified } from "./accountShared.js";
 
 const { div, span, button, h3, p } = van.tags;
 
@@ -20,6 +20,15 @@ const PLAYER_SELECTION_MESSAGE =
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const isOwned = (owned) => Number(owned) === 1;
 const bundlePath = (code) => `${BUNDLES_RECEIVED_PATH}.${code}`;
+const createDeferred = () => {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+};
 
 const matchesSearch = (bundle, query) => {
     const normalizedQuery = String(query ?? "")
@@ -72,7 +81,7 @@ const BundleRow = ({ bundle, state, searchQuery, buyAllStatus, onBuy, onUnbuy })
                 },
                 () => {
                     if (state.pending.val) return "BUY QUEUED";
-                    if (state.status.val === "loading") return "UNBUYING";
+                    if (state.status.val === "loading") return isOwned(state.owned.val) ? "UNBUYING" : "BUYING";
                     return isOwned(state.owned.val) ? "UNBUY" : "BUY";
                 }
             ),
@@ -139,25 +148,20 @@ export const BundlesTab = () => {
     const buyAllDialogOpen = van.state(false);
     const buyAllCountdown = van.state(0);
     const buyAllTargetCount = van.state(0);
-    const buyAllStatus = van.state("idle");
+    const { status: buyAllStatus, run: runBuyAll } = useWriteStatus();
     const listNode = div({ class: "account-item-stack bundles-list" });
     const reconcileRows = createStaticRowReconciler(listNode);
     let catalogCache = [];
     let buyAllCountdownTimer = null;
 
-    const resetBuyAllStatusAfter = (status, delayMs) => {
-        setTimeout(() => {
-            if (buyAllStatus.val === status) buyAllStatus.val = "idle";
-        }, delayMs);
-    };
-
     const getBundleState = (code, owned = 0) => {
         if (!bundleStates.has(code)) {
+            const { status, run } = useWriteStatus();
             bundleStates.set(code, {
                 owned: van.state(isOwned(owned) ? 1 : 0),
                 pending: van.state(false),
-                status: van.state("idle"),
-                statusResetTimer: null,
+                status,
+                run,
             });
         }
         return bundleStates.get(code);
@@ -170,33 +174,6 @@ export const BundlesTab = () => {
         });
 
     const buyableCount = van.derive(() => getBuyableBundles().length);
-
-    const clearStatusResetTimer = (state) => {
-        if (state.statusResetTimer !== null) {
-            clearTimeout(state.statusResetTimer);
-            state.statusResetTimer = null;
-        }
-    };
-
-    const resetStatusAfter = (state, delayMs) => {
-        clearStatusResetTimer(state);
-        state.statusResetTimer = setTimeout(() => {
-            state.status.val = "idle";
-            state.statusResetTimer = null;
-        }, delayMs);
-    };
-
-    const markPurchaseSucceeded = (state) => {
-        state.pending.val = false;
-        state.status.val = "success";
-        resetStatusAfter(state, 1200);
-    };
-
-    const markPurchaseFailed = (state) => {
-        state.pending.val = false;
-        state.status.val = "error";
-        resetStatusAfter(state, 1800);
-    };
 
     const ensurePlayerSelected = async () => {
         try {
@@ -288,15 +265,15 @@ export const BundlesTab = () => {
     };
 
     const pollForOwnershipBatch = async (entries) => {
-        const pendingEntries = new Map(entries.map(({ bundle, state }) => [bundle.code, state]));
+        const pendingEntries = new Map(entries.map((entry) => [entry.bundle.code, entry]));
 
         for (let attempt = 0; attempt < BUY_POLL_ATTEMPTS && pendingEntries.size; attempt += 1) {
             await delay(BUY_POLL_INTERVAL_MS);
             await refreshCatalog();
 
-            for (const [code, state] of pendingEntries) {
-                if (!isOwned(state.owned.val)) continue;
-                markPurchaseSucceeded(state);
+            for (const [code, entry] of pendingEntries) {
+                if (!isOwned(entry.state.owned.val)) continue;
+                entry.confirmation.resolve();
                 pendingEntries.delete(code);
             }
         }
@@ -304,109 +281,109 @@ export const BundlesTab = () => {
         return pendingEntries;
     };
 
-    const queueBundleBuy = async (bundle, state) => {
-        clearStatusResetTimer(state);
-        state.pending.val = true;
-        state.status.val = "idle";
-
-        try {
-            await executeCheatAction(`buy ${bundle.code}`);
-            return true;
-        } catch (caughtError) {
-            console.error(`[bundles] Buy failed for ${bundle.code}:`, caughtError);
-            markPurchaseFailed(state);
-            return false;
-        }
-    };
-
     async function buyBundle(bundle, state) {
         if (buyAllStatus.val === "loading" || isOwned(state.owned.val) || state.pending.val) return;
-        if (!(await ensurePlayerSelected())) {
-            markPurchaseFailed(state);
-            return;
-        }
+        return state.run(
+            async () => {
+                if (!(await ensurePlayerSelected()))
+                    throw new Error(purchaseBlockMessage.val ?? PLAYER_SELECTION_MESSAGE);
 
-        if (!(await queueBundleBuy(bundle, state))) return;
-
-        try {
-            const confirmed = await pollForOwnership(bundle.code, state);
-            if (confirmed) {
-                markPurchaseSucceeded(state);
-            } else {
-                markPurchaseFailed(state);
-            }
-        } catch (caughtError) {
-            console.error(`[bundles] Ownership poll failed for ${bundle.code}:`, caughtError);
-            markPurchaseFailed(state);
-        }
+                state.pending.val = true;
+                try {
+                    await executeCheatAction(`buy ${bundle.code}`);
+                    const confirmed = await pollForOwnership(bundle.code, state);
+                    if (!confirmed) throw new Error(`Timed out confirming ownership of ${bundle.code}.`);
+                } finally {
+                    state.pending.val = false;
+                }
+            },
+            { onError: (caughtError) => console.error(`[bundles] Buy failed for ${bundle.code}:`, caughtError) }
+        );
     }
 
     async function buyAllBundles() {
         if (buyAllCountdown.val > 0 || buyAllStatus.val === "loading") return;
-        buyAllStatus.val = "loading";
-        if (!(await ensurePlayerSelected())) {
-            closeBuyAllDialog();
-            buyAllStatus.val = "error";
-            resetBuyAllStatusAfter("error", 1800);
-            return;
-        }
-
-        const bundles = getBuyableBundles();
-        closeBuyAllDialog();
-        if (!bundles.length) {
-            buyAllStatus.val = "idle";
-            return;
-        }
-
-        const queued = [];
-        let queueRequestFailed = false;
-
-        for (const bundle of bundles) {
-            const state = getBundleState(bundle.code, bundle.owned);
-            if (await queueBundleBuy(bundle, state)) queued.push({ bundle, state });
-            else queueRequestFailed = true;
-        }
-
-        if (!queued.length) {
-            buyAllStatus.val = "error";
-            resetBuyAllStatusAfter("error", 1800);
-            return;
-        }
-
-        try {
-            const pending = await pollForOwnershipBatch(queued);
-            for (const state of pending.values()) markPurchaseFailed(state);
-
-            const completed = !queueRequestFailed && pending.size === 0;
-            buyAllStatus.val = completed ? "success" : "error";
-            resetBuyAllStatusAfter(completed ? "success" : "error", completed ? 1200 : 1800);
-        } catch (caughtError) {
-            console.error("[bundles] Ownership poll failed after Buy All:", caughtError);
-            for (const { state } of queued) {
-                if (!isOwned(state.owned.val)) markPurchaseFailed(state);
+        return runBuyAll(async () => {
+            if (!(await ensurePlayerSelected())) {
+                closeBuyAllDialog();
+                throw new Error(purchaseBlockMessage.val ?? PLAYER_SELECTION_MESSAGE);
             }
-            buyAllStatus.val = "error";
-            resetBuyAllStatusAfter("error", 1800);
-        }
+
+            const bundles = getBuyableBundles();
+            closeBuyAllDialog();
+            if (!bundles.length) return;
+
+            let queueTail = Promise.resolve();
+            const queueSequentially = (task) => {
+                const request = queueTail.then(task, task);
+                queueTail = request.catch(() => undefined);
+                return request;
+            };
+            const entries = bundles.map((bundle) => {
+                const state = getBundleState(bundle.code, bundle.owned);
+                const entry = {
+                    bundle,
+                    state,
+                    confirmation: createDeferred(),
+                    queued: false,
+                    request: null,
+                    result: null,
+                };
+
+                entry.result = state.run(
+                    async () => {
+                        try {
+                            entry.request = queueSequentially(async () => {
+                                state.pending.val = true;
+                                await executeCheatAction(`buy ${bundle.code}`);
+                                entry.queued = true;
+                            });
+                            await entry.request;
+                            await entry.confirmation.promise;
+                        } finally {
+                            state.pending.val = false;
+                        }
+                    },
+                    { onError: (caughtError) => console.error(`[bundles] Buy failed for ${bundle.code}:`, caughtError) }
+                );
+                return entry;
+            });
+
+            await Promise.allSettled(entries.map((entry) => entry.request));
+            const queued = entries.filter((entry) => entry.queued);
+
+            if (queued.length) {
+                try {
+                    const pending = await pollForOwnershipBatch(queued);
+                    for (const entry of pending.values()) {
+                        entry.confirmation.reject(new Error(`Timed out confirming ownership of ${entry.bundle.code}.`));
+                    }
+                } catch (caughtError) {
+                    console.error("[bundles] Ownership poll failed after Buy All:", caughtError);
+                    for (const entry of queued) {
+                        if (!isOwned(entry.state.owned.val)) entry.confirmation.reject(caughtError);
+                    }
+                }
+            }
+
+            const results = await Promise.all(entries.map((entry) => entry.result));
+            if (results.some(({ ok }) => !ok)) throw new Error("One or more bundle purchases could not be completed.");
+        });
     }
 
     async function unbuyBundle(bundle, state) {
         if (buyAllStatus.val === "loading" || !isOwned(state.owned.val) || state.pending.val) return;
 
-        clearStatusResetTimer(state);
-        state.status.val = "loading";
-        try {
-            // Unbuy is deliberately the only direct ownership write, and it can
-            // only write 0. writeVerified reads the flag back before this updates.
-            await writeVerified(bundlePath(bundle.code), 0);
-            state.owned.val = 0;
-            state.pending.val = false;
-            state.status.val = "success";
-            resetStatusAfter(state, 1200);
-        } catch (caughtError) {
-            console.error(`[bundles] Unbuy failed for ${bundle.code}:`, caughtError);
-            markPurchaseFailed(state);
-        }
+        return state.run(
+            async () => {
+                // Unbuy is deliberately the only direct ownership write, and it can
+                // only write 0. writeVerified reads the flag back before this updates.
+                await writeVerified(bundlePath(bundle.code), 0);
+                state.owned.val = 0;
+                state.pending.val = false;
+            },
+            { onError: (caughtError) => console.error(`[bundles] Unbuy failed for ${bundle.code}:`, caughtError) }
+        );
     }
 
     const load = () => runLoad(refreshCatalog);

--- a/src/ui/entry/style.css
+++ b/src/ui/entry/style.css
@@ -21,6 +21,7 @@
 @import url("../styles/_world-tabs.css");
 @import url("../styles/_account-pages.css");
 @import url("../styles/_cards.css");
+@import url("../styles/_bundles.css");
 @import url("../styles/tabs/w1/_index.css");
 @import url("../styles/tabs/w2/_index.css");
 @import url("../styles/tabs/w3/_index.css");

--- a/src/ui/services/api.js
+++ b/src/ui/services/api.js
@@ -47,6 +47,12 @@ export async function fetchCheatsData() {
     return _request("/cheats");
 }
 
+/** Fetch bundle names, codes, and live ownership flags from the injected runtime. */
+export async function fetchBundleCatalog() {
+    const data = await _request("/game/bundles");
+    return data.bundles;
+}
+
 export async function executeCheatAction(action) {
     return _request("/toggle", {
         method: "POST",

--- a/src/ui/styles/_bundles.css
+++ b/src/ui/styles/_bundles.css
@@ -1,0 +1,118 @@
+.bundles-scroll {
+    width: 100%;
+}
+
+.bundles-search {
+    max-width: 480px;
+}
+
+.bundles-list {
+    min-width: 0;
+}
+
+.bundle-row-wrap[hidden] {
+    display: none;
+}
+
+.bundle-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.bundle-row__code {
+    font-family: var(--font-mono);
+}
+
+.bundle-row__pending {
+    margin-top: 2px;
+    color: var(--c-warning);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+}
+
+.bundle-row .account-row__badge {
+    box-sizing: border-box;
+    display: inline-flex;
+    width: 88px;
+    align-items: center;
+    justify-content: center;
+}
+
+.bundle-row__badge--owned {
+    color: var(--c-success);
+    border-color: var(--c-success);
+    background: var(--c-success-10);
+}
+
+.bundle-row__badge--unowned {
+    color: var(--c-text-muted);
+}
+
+.bundle-row__badge--queued {
+    color: var(--c-warning);
+    border-color: var(--c-warning);
+    background: color-mix(in srgb, var(--c-warning) 12%, var(--c-panel));
+}
+
+.bundle-row__controls {
+    min-width: 132px;
+}
+
+.bundle-row__action {
+    width: 100%;
+    padding-inline: 14px;
+}
+
+.bundle-row__action:disabled {
+    opacity: 0.68;
+    cursor: wait;
+}
+
+.bundles-buy-all-modal .modal-box {
+    border-color: var(--c-warning);
+    box-shadow: 0 0 30px color-mix(in srgb, var(--c-warning) 20%, transparent);
+}
+
+.bundles-buy-all-modal .modal-header {
+    background: color-mix(in srgb, var(--c-warning) 10%, var(--c-panel));
+    border-bottom-color: var(--c-warning);
+}
+
+.bundles-buy-all-modal .modal-header h3 {
+    color: var(--c-warning);
+}
+
+.bundles-buy-all-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.bundles-buy-all-modal__body p {
+    margin: 0;
+    line-height: 1.45;
+}
+
+.bundles-buy-all-modal__warning {
+    color: var(--c-warning);
+    font-weight: 700;
+}
+
+.bundles-buy-all-modal__countdown {
+    color: var(--c-text-muted);
+    font-family: var(--font-mono);
+}
+
+@media (max-width: 680px) {
+    .bundle-row {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .bundle-row .account-row__controls {
+        grid-column: 1 / -1;
+    }
+
+    .bundle-row__controls {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary

- add an Account > Bundles page with search, live ownership status, individual buy/unbuy controls, and Buy All
- expose a read-only bundle catalog API from the injected runtime
- keep the UI catalog limited to manually named `knownBundles`, while existing autocomplete can still discover live unknown codes
- verify ownership after purchases and recover cleanly from queue failures or confirmation timeouts

## Game interactions

- reads ownership from `gga.BundlesReceived.h`
- purchases use the existing `buy <bundleCode>` cheat, which queues `firebase.addToMessageQueue("SERVER_CODE", "SERVER_ITEM_BUNDLE", code)`
- Unbuy performs a verified write of `0` to `gga.BundlesReceived.h.<bundleCode>`; it does not remove delivered items or Slab entries

## Safety and behavior

- requires an active in-game character before queueing purchases
- Buy All has a five-second confirmation and disables individual row actions while running
- single and bulk purchases poll live ownership for up to ten seconds
- timeouts and partial failures clear pending state and allow retry instead of leaving rows locked