### PR TITLE
feat(w1): add PetMart+ tier to companion cheat

### DIFF
--- a/src/cheats/proxies/firebase.js
+++ b/src/cheats/proxies/firebase.js
@@ -44,8 +44,8 @@ export function setupFirebaseStorageProxy() {
     firebase.getCompanionInfoMe = function (...args) {
         if (cheatState.w1.companion) {
             if (!cheatConfig.w1.companion.companions) {
-                return Array.from({ length: cList.CompanionDB.length }, (_, index) => index).filter(
-                    (index) => monsterDefs[cList.CompanionDB[index][0]]?.h.Name
+                return Array.from({ length: cList.CompanionDB.length }, (_, index) => `${index},0,0,0,1`).filter(
+                    (entry) => monsterDefs[cList.CompanionDB[parseInt(entry)][0]]?.h.Name
                 );
             }
             const companions = cheatConfig.w1.companion.companions;
@@ -53,7 +53,15 @@ export function setupFirebaseStorageProxy() {
                 return companions
                     .split(",")
                     .map((id) => parseInt(id.trim()))
-                    .filter((id) => !isNaN(id));
+                    .filter((id) => !isNaN(id))
+                    .map((id) => `${id},0,0,0,1`);
+            }
+            if (Array.isArray(companions)) {
+                return companions.map((entry) => {
+                    if (typeof entry === "number") return `${entry},0,0,0,1`;
+                    if (typeof entry === "string" && !entry.includes(",")) return `${entry},0,0,0,1`;
+                    return entry;
+                });
             }
             return companions;
         }


### PR DESCRIPTION
### Summary
Updates `firebase.getCompanionInfoMe` in the World 1 companion proxy to format unlocked companions with upgraded tier level 1 (`"${id},0,0,0,1"`).

### Details
- Formats each companion entry string so `split(",")[4]` returns level 1, enabling PetMart+ upgraded tier status.
- Activates upgraded star ratings (`CompanionDB[id][9]`) and enhanced companion bonuses (`CompanionDB[id][11]`) across the account when `w1.companion` is enabled.
- Supports both default all-pet mode and custom comma-separated/array companion ID lists in `cheatConfig.w1.companion.companions`.
