### PR TITLE
feat(w1): per-pet PetMart+ in the Pets tab

### DIFF
--- a/src/cheats/core/state.js
+++ b/src/cheats/core/state.js
@@ -38,10 +38,24 @@ export function setCheatConfig(config) {
  * @param {object} newConfig - New configuration to merge
  */
 export function updateCheatConfig(newConfig) {
-    for (const key in newConfig) {
-        if (Object.hasOwnProperty.call(newConfig, key)) {
-            cheatConfig[key] = newConfig[key];
-        }
+    mergeCheatConfig(cheatConfig, newConfig);
+}
+
+const isPlainObject = (value) => !!value && typeof value === "object" && !Array.isArray(value);
+
+/**
+ * Merge a (possibly partial) config into the live one.
+ *
+ * Callers send only the branch they changed, so assigning top-level keys would drop
+ * every sibling - a post of just `w1.companion` used to wipe w1.anvil/forge/owl in the
+ * running game. Arrays are replaced whole so a list can be shortened or emptied.
+ */
+function mergeCheatConfig(target, source) {
+    for (const key in source) {
+        if (!Object.hasOwnProperty.call(source, key)) continue;
+        const value = source[key];
+        if (isPlainObject(value) && isPlainObject(target[key])) mergeCheatConfig(target[key], value);
+        else target[key] = value;
     }
 }
 /**

--- a/src/cheats/proxies/firebase.js
+++ b/src/cheats/proxies/firebase.js
@@ -41,6 +41,19 @@ export function setupFirebaseStorageProxy() {
     };
 
     const getCompanionInfoMe = firebase.getCompanionInfoMe;
+    const companionEntryId = (entry) => parseInt(String(entry).split(",")[0]);
+
+    // A configured list names the pets to fake-own, it does not describe the whole
+    // collection: the player's real companions are merged back in, entries the config
+    // mentions winning on id. Without this, listing one pet silently deletes every pet
+    // actually owned, which the W1 Pets tab hits every time it marks a single pet.
+    const mergeWithOwnedCompanions = (entries, self, args) => {
+        const owned = Reflect.apply(getCompanionInfoMe, self, args) || [];
+        const byId = new Map(owned.map((entry) => [companionEntryId(entry), entry]));
+        entries.forEach((entry) => byId.set(companionEntryId(entry), entry));
+        return [...byId.values()];
+    };
+
     firebase.getCompanionInfoMe = function (...args) {
         if (cheatState.w1.companion) {
             if (!cheatConfig.w1.companion.companions) {
@@ -50,18 +63,20 @@ export function setupFirebaseStorageProxy() {
             }
             const companions = cheatConfig.w1.companion.companions;
             if (typeof companions === "string") {
-                return companions
+                const entries = companions
                     .split(",")
                     .map((id) => parseInt(id.trim()))
                     .filter((id) => !isNaN(id))
                     .map((id) => `${id},0,0,0,1`);
+                return mergeWithOwnedCompanions(entries, this, args);
             }
             if (Array.isArray(companions)) {
-                return companions.map((entry) => {
+                const entries = companions.map((entry) => {
                     if (typeof entry === "number") return `${entry},0,0,0,1`;
                     if (typeof entry === "string" && !entry.includes(",")) return `${entry},0,0,0,1`;
                     return entry;
                 });
+                return mergeWithOwnedCompanions(entries, this, args);
             }
             return companions;
         }

--- a/src/ui/components/views/account/w1/CompanionsTab.js
+++ b/src/ui/components/views/account/w1/CompanionsTab.js
@@ -12,7 +12,16 @@
  */
 
 import van from "../../../../vendor/van-1.6.0.js";
-import { gga, readCList, readGgaEntries } from "../../../../services/api.js";
+import {
+    executeCheatAction,
+    fetchCheatStates,
+    fetchConfig,
+    gga,
+    readCList,
+    readGgaEntries,
+    saveConfigFile,
+    updateSessionConfig,
+} from "../../../../services/api.js";
 import { EmptyState } from "../../../EmptyState.js";
 import { SearchBar } from "../../../SearchBar.js";
 import { Icons } from "../../../../assets/icons.js";
@@ -26,6 +35,22 @@ import { cleanName, cleanNameEffect, useWriteStatus, writeVerified } from "../ac
 const { div, button, span, label, input } = van.tags;
 
 const TOKEN_PATH = "OptionsListAccount[606]";
+
+// Pets+ rides on the existing W1 Companion cheat: `cheatConfig.w1.companion.companions`
+// is a comma-separated id list, and the cheat reports every listed pet to the game as
+// owned at the upgraded tier. An EMPTY list is the shipped default and means "every pet",
+// so "no Pets+ pets" is expressed by clearing the list and turning the cheat off.
+const parsePlusIds = (value) => {
+    if (!Array.isArray(value)) return parseIdList(value);
+    // Hand-written array form: "<id>,a,b,c,<tier>" - only tier 1 counts as Pets+.
+    return value
+        .map((entry) => {
+            const parts = String(entry).split(",");
+            if (parts.length > 4 && parts[4].trim() !== "1") return Number.NaN;
+            return Number.parseInt(parts[0], 10);
+        })
+        .filter((id) => Number.isFinite(id));
+};
 
 const normalizeSearchText = (value) => String(value ?? "").trim().toLowerCase();
 
@@ -65,8 +90,10 @@ const buildCompanionRows = (rawCompanionDb, rawMonsterDefs) =>
             if (!name) return null;
 
             const effect = cleanNameEffect(row[1], "No buff text");
+            // Column 10 is the upgraded-tier buff text the game shows for a Pets+ pet.
+            const plusEffect = cleanNameEffect(row[10], effect);
 
-            return { id, monsterKey, name, effect, isUnused: isUnusedPetText(effect) };
+            return { id, monsterKey, name, effect, plusEffect, isUnused: isUnusedPetText(effect) };
         })
         .filter(Boolean);
 
@@ -108,24 +135,48 @@ const buildSections = (pets, rawSetsInfo) => {
     return sections;
 };
 
-const CompanionCard = ({ companion, enabledIds, onToggle }) =>
-    button(
-        {
-            type: "button",
-            class: () =>
-                ["companion-card", enabledIds.val.has(companion.id) && "companion-card--enabled"]
-                    .filter(Boolean)
-                    .join(" "),
-            "aria-pressed": () => enabledIds.val.has(companion.id),
-            onclick: () => onToggle(companion.id),
-            title: "Click: toggle this pet's account bonus.",
-        },
-        div(
-            { class: "companion-card__top" },
-            div({ class: "companion-card__name" }, companion.name),
-            span({ class: "companion-card__id" }, `ID ${companion.id}`)
+// The "+" control is a sibling of the card rather than a child, because the card is
+// itself a button and buttons cannot nest.
+const CompanionCard = ({ companion, enabledIds, isPlus, onToggle, onTogglePlus }) =>
+    div(
+        { class: "companion-card-wrap" },
+        button(
+            {
+                type: "button",
+                class: () =>
+                    [
+                        "companion-card",
+                        enabledIds.val.has(companion.id) && "companion-card--enabled",
+                        isPlus(companion.id) && "companion-card--plus",
+                    ]
+                        .filter(Boolean)
+                        .join(" "),
+                "aria-pressed": () => enabledIds.val.has(companion.id),
+                onclick: () => onToggle(companion.id),
+                title: "Click: toggle this pet's account bonus (pet token).",
+            },
+            div(
+                { class: "companion-card__top" },
+                div({ class: "companion-card__name" }, companion.name),
+                span({ class: "companion-card__id" }, `ID ${companion.id}`)
+            ),
+            div({ class: "companion-card__effect" }, () =>
+                isPlus(companion.id) ? companion.plusEffect : companion.effect
+            )
         ),
-        div({ class: "companion-card__effect" }, companion.effect)
+        withTooltip(
+            button(
+                {
+                    type: "button",
+                    class: () => ["companion-plus", isPlus(companion.id) && "companion-plus--on"].filter(Boolean).join(" "),
+                    "aria-pressed": () => isPlus(companion.id),
+                    "aria-label": `Pets+ tier for ${companion.name}`,
+                    onclick: () => onTogglePlus(companion.id),
+                },
+                "+"
+            ),
+            "Pets+ tier. Only while the injector runs, and it clears this pet's pet token."
+        )
     );
 
 export const CompanionsTab = () => {
@@ -135,8 +186,14 @@ export const CompanionsTab = () => {
     const companions = van.state([]);
     const sections = van.state([]);
     const enabledIds = van.state(new Set());
+    const plusIds = van.state(new Set());
+    // True when the W1 Companion cheat is on with an empty list, which the game reads as
+    // "every pet, upgraded". The cards have to show that, not an empty selection.
+    const plusAll = van.state(false);
     const hideUnused = van.state(false);
     const searchQuery = van.state("");
+
+    const isPlus = (id) => plusAll.val || plusIds.val.has(id);
 
     const eligibleIds = () => companions.val.filter((companion) => !companion.isUnused).map((companion) => companion.id);
 
@@ -161,6 +218,14 @@ export const CompanionsTab = () => {
 
             const tokenValue = await gga(TOKEN_PATH);
             enabledIds.val = new Set(parseIdList(tokenValue).filter((id) => validIdSet.has(id)));
+
+            const [config, cheatStates] = await Promise.all([fetchConfig(), fetchCheatStates()]);
+            const cheatOn = !!cheatStates?.data?.w1?.companion;
+            const configured = config?.cheatConfig?.w1?.companion?.companions ?? "";
+            plusAll.val = cheatOn && !configured;
+            plusIds.val = cheatOn
+                ? new Set(parsePlusIds(configured).filter((id) => validIdSet.has(id)))
+                : new Set();
         });
 
     const writeTokens = (idSet) =>
@@ -169,7 +234,42 @@ export const CompanionsTab = () => {
             enabledIds.val = idSet;
         });
 
+    // /api/toggle flips a cheat rather than setting it, so acting on the state this tab
+    // loaded with can switch it off while reporting success. Re-read, act, then confirm.
+    const setCompanionCheat = async (wanted) => {
+        const before = !!(await fetchCheatStates())?.data?.w1?.companion;
+        if (before !== wanted) await executeCheatAction("w1 companion");
+        const after = !!(await fetchCheatStates())?.data?.w1?.companion;
+        if (after !== wanted) throw new Error(`Could not turn the W1 Companion cheat ${wanted ? "on" : "off"}`);
+    };
+
+    // /api/config/save rewrites config.custom.js from whatever it is handed, so it needs
+    // the whole config - a partial would drop every other saved override.
+    const persistConfig = async () => {
+        const config = await fetchConfig();
+        if (!config?.cheatConfig) throw new Error("Could not read the config back to save it");
+        await saveConfigFile({
+            startupCheats: config.startupCheats ?? [],
+            cheatConfig: config.cheatConfig,
+            injectorConfig: config.injectorConfig,
+        });
+    };
+
+    const writePlus = (idSet) =>
+        runWrite(async () => {
+            const ids = [...idSet].sort((a, b) => a - b);
+            await updateSessionConfig({ cheatConfig: { w1: { companion: { companions: ids.join(",") } } } });
+            await setCompanionCheat(ids.length > 0);
+            await persistConfig();
+            plusIds.val = idSet;
+            plusAll.val = false;
+        });
+
     const isBusy = () => loading.val || writeStatus.val === "loading";
+
+    // A pet in the token list has its bonus overwritten with the base value by the game,
+    // even when the cheat marks it upgraded - measured. So the two sets must stay disjoint.
+    const currentPlusSet = () => (plusAll.val ? new Set(eligibleIds()) : new Set(plusIds.val));
 
     const handleToggle = async (companionId) => {
         if (isBusy()) return;
@@ -178,12 +278,42 @@ export const CompanionsTab = () => {
         if (next.has(companionId)) next.delete(companionId);
         else next.add(companionId);
 
+        if (next.has(companionId) && isPlus(companionId)) {
+            const plus = currentPlusSet();
+            plus.delete(companionId);
+            await writePlus(plus);
+        }
         await writeTokens(next);
+    };
+
+    const handleTogglePlus = async (companionId) => {
+        if (isBusy()) return;
+
+        const next = currentPlusSet();
+        if (next.has(companionId)) next.delete(companionId);
+        else next.add(companionId);
+
+        if (next.has(companionId) && enabledIds.val.has(companionId)) {
+            const tokens = new Set(enabledIds.val);
+            tokens.delete(companionId);
+            await writeTokens(tokens);
+        }
+        await writePlus(next);
     };
 
     const handleBulkWrite = async (ids) => {
         if (isBusy()) return;
-        await writeTokens(new Set(ids));
+        await writeTokens(new Set(ids.filter((id) => !isPlus(id))));
+    };
+
+    // The token list is a saved account value the game and other devices also write, so an
+    // overlap can appear without this tab doing anything. Surface it rather than claim it
+    // cannot happen.
+    const overlapIds = () => [...enabledIds.val].filter((id) => isPlus(id));
+
+    const handleFixOverlap = async () => {
+        if (isBusy()) return;
+        await writeTokens(new Set([...enabledIds.val].filter((id) => !isPlus(id))));
     };
 
     load();
@@ -225,7 +355,13 @@ export const CompanionsTab = () => {
                     div(
                         { class: "companions-grid" },
                         ...section.companions.map((companion) =>
-                            CompanionCard({ companion, enabledIds, onToggle: handleToggle })
+                            CompanionCard({
+                                companion,
+                                enabledIds,
+                                isPlus,
+                                onToggle: handleToggle,
+                                onTogglePlus: handleTogglePlus,
+                            })
                         )
                     )
                 )
@@ -262,18 +398,56 @@ export const CompanionsTab = () => {
         withTooltip(
             button({ class: "btn-secondary", onclick: () => handleBulkWrite([]), disabled: () => isBusy() }, "CLEAR ALL"),
             "Deactivate all pet bonuses."
+        ),
+        withTooltip(
+            button(
+                { class: "btn-secondary", onclick: () => writePlus(new Set()), disabled: () => isBusy() },
+                "CLEAR PETS+"
+            ),
+            "Drop every pet back to its normal tier and turn the W1 Companion cheat off."
         )
     );
+
+    const renderNotices = () => {
+        const overlap = overlapIds();
+        return div(
+            plusAll.val
+                ? div(
+                      { class: "companions-notice" },
+                      "Every pet is on the Pets+ tier: the W1 Companion cheat is on with an empty pet list. " +
+                          "Click + on a pet to switch to picking them individually."
+                  )
+                : null,
+            overlap.length
+                ? div(
+                      { class: "companions-notice companions-notice--warn" },
+                      `${overlap.length} pet${overlap.length === 1 ? " is" : "s are"} in both the pet-token list and Pets+. ` +
+                          "The game overwrites Pets+ with the normal bonus for those, so they are not actually upgraded.",
+                      button(
+                          { class: "btn-secondary", onclick: handleFixOverlap, disabled: () => isBusy() },
+                          "REMOVE THEIR TOKENS"
+                      )
+                  )
+                : null
+        );
+    };
 
     return PersistentAccountListPage({
         rootClass: "tab-container",
         title: "PETS",
-        description: "Left click toggles a pet's account-wide bonus (pet token). Writes bypass the in-game token limit.",
+        description:
+            "Left click toggles a pet's account-wide bonus (pet token) - saved to your account, works without the injector. " +
+            "The + button puts a pet on the Pets+ tier instead: that runs through the W1 Companion cheat, so it only lasts " +
+            "while the injector is running, it changes your active follower, and a pet cannot be on a token and on Pets+ at once.",
         actions: RefreshButton({ onRefresh: load, tooltip: "Re-read live companion data from the running game." }),
         subNav,
         state: { loading, error },
         loadingText: "READING PETS",
         errorTitle: "PET READ FAILED",
-        body: div({ class: "scrollable-panel companions-scroll" }, () => renderSearchResults()),
+        body: div(
+            { class: "scrollable-panel companions-scroll" },
+            () => renderNotices(),
+            () => renderSearchResults()
+        ),
     });
 };

--- a/src/ui/components/views/account/w1/CompanionsTab.js
+++ b/src/ui/components/views/account/w1/CompanionsTab.js
@@ -27,7 +27,7 @@ import { SearchBar } from "../../../SearchBar.js";
 import { Icons } from "../../../../assets/icons.js";
 import { withTooltip } from "../../../Tooltip.js";
 import { toIndexedArray } from "../../../../utils/index.js";
-import { RefreshButton } from "../components/AccountPageChrome.js";
+import { RefreshButton, WarningBanner } from "../components/AccountPageChrome.js";
 import { PersistentAccountListPage } from "../components/PersistentAccountListPage.js";
 import { useAccountLoad } from "../accountLoadPolicy.js";
 import { cleanName, cleanNameEffect, useWriteStatus, writeVerified } from "../accountShared.js";
@@ -410,21 +410,25 @@ export const CompanionsTab = () => {
 
     const renderNotices = () => {
         const overlap = overlapIds();
+        if (!plusAll.val && !overlap.length) return null;
         return div(
             plusAll.val
-                ? div(
-                      { class: "companions-notice" },
+                ? WarningBanner(
                       "Every pet is on the Pets+ tier: the W1 Companion cheat is on with an empty pet list. " +
                           "Click + on a pet to switch to picking them individually."
                   )
                 : null,
             overlap.length
-                ? div(
-                      { class: "companions-notice companions-notice--warn" },
+                ? WarningBanner(
                       `${overlap.length} pet${overlap.length === 1 ? " is" : "s are"} in both the pet-token list and Pets+. ` +
                           "The game overwrites Pets+ with the normal bonus for those, so they are not actually upgraded.",
                       button(
-                          { class: "btn-secondary", onclick: handleFixOverlap, disabled: () => isBusy() },
+                          {
+                              type: "button",
+                              class: "btn-secondary",
+                              onclick: handleFixOverlap,
+                              disabled: () => isBusy(),
+                          },
                           "REMOVE THEIR TOKENS"
                       )
                   )
@@ -440,14 +444,11 @@ export const CompanionsTab = () => {
             "The + button puts a pet on the Pets+ tier instead: that runs through the W1 Companion cheat, so it only lasts " +
             "while the injector is running, it changes your active follower, and a pet cannot be on a token and on Pets+ at once.",
         actions: RefreshButton({ onRefresh: load, tooltip: "Re-read live companion data from the running game." }),
+        topNotices: () => renderNotices(),
         subNav,
         state: { loading, error },
         loadingText: "READING PETS",
         errorTitle: "PET READ FAILED",
-        body: div(
-            { class: "scrollable-panel companions-scroll" },
-            () => renderNotices(),
-            () => renderSearchResults()
-        ),
+        body: div({ class: "scrollable-panel companions-scroll" }, () => renderSearchResults()),
     });
 };

--- a/src/ui/styles/_utilities.css
+++ b/src/ui/styles/_utilities.css
@@ -65,6 +65,15 @@
 
 .warning-banner__content {
     min-width: 0;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.warning-banner .btn-secondary {
+    margin-left: auto;
+    flex-shrink: 0;
 }
 
 .warning-banner__highlight {

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -32,30 +32,6 @@
     gap: 10px;
 }
 
-.companions-notice {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 12px;
-    font-size: 0.75rem;
-    line-height: 1.45;
-    color: var(--c-text-dim);
-    background: var(--c-panel);
-    border: 1px solid var(--c-border);
-    border-radius: var(--radius-md);
-    margin-bottom: 10px;
-}
-
-.companions-notice--warn {
-    border-color: var(--c-warning);
-    color: var(--c-text-main);
-}
-
-.companions-notice .btn-secondary {
-    flex-shrink: 0;
-    margin-left: auto;
-}
-
 /* The card is a button, so the + control sits beside it and is positioned over it. */
 .companion-card-wrap {
     position: relative;

--- a/src/ui/styles/tabs/w1/_companions.css
+++ b/src/ui/styles/tabs/w1/_companions.css
@@ -32,6 +32,75 @@
     gap: 10px;
 }
 
+.companions-notice {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    color: var(--c-text-dim);
+    background: var(--c-panel);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    margin-bottom: 10px;
+}
+
+.companions-notice--warn {
+    border-color: var(--c-warning);
+    color: var(--c-text-main);
+}
+
+.companions-notice .btn-secondary {
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+/* The card is a button, so the + control sits beside it and is positioned over it. */
+.companion-card-wrap {
+    position: relative;
+    display: flex;
+}
+
+.companion-plus {
+    position: absolute;
+    right: 8px;
+    bottom: 8px;
+    width: 22px;
+    height: 22px;
+    display: grid;
+    place-items: center;
+    font: inherit;
+    font-weight: 700;
+    line-height: 1;
+    color: var(--c-text-muted);
+    background: var(--c-black-40);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    appearance: none;
+    transition:
+        border-color 0.15s,
+        background 0.15s,
+        color 0.15s;
+}
+
+.companion-plus:hover {
+    border-color: var(--c-accent);
+    color: var(--c-text-main);
+}
+
+.companion-plus:focus-visible {
+    outline: 2px solid var(--c-accent);
+    outline-offset: 2px;
+}
+
+.companion-plus--on {
+    border-color: var(--c-accent);
+    background: var(--c-accent);
+    color: var(--c-panel);
+}
+
 .companion-card {
     display: flex;
     flex-direction: column;
@@ -66,6 +135,15 @@
 .companion-card--enabled {
     border-color: var(--c-success);
     background: var(--c-success-10);
+}
+
+.companion-card--plus {
+    border-color: var(--c-accent);
+}
+
+/* The + control overlaps the buff text, which is the tallest thing in the card. */
+.companion-card__effect {
+    padding-right: 26px;
 }
 
 .companion-card__top {


### PR DESCRIPTION
Adds a `+` control to every card in **Account Options → W1 → Pets**, putting that pet on the upgraded (PetMart+) tier individually, instead of the all-or-nothing behaviour of `w1 companion` with an empty list.

No new cheat and no polling: it writes the pet's id into `cheatConfig.w1.companion.companions`, which #225 already turns into an upgraded-tier entry, and enables `w1 companion`. The game rebuilds `DNSM.CompanionLVz` and `CompanionBon` from that list in `ActorEvents_577.init` on every map load, so the upgraded bonus, the `+` glyph, the upgraded buff text (`CompanionDB[id][10]`) and the Pet Tourney power all come from the game itself. Nothing writes `DNSM`, so nothing has to be re-applied.

### Pet tokens and PetMart+ cannot both apply to one pet

This shaped the design, and it is a property of the game rather than of this change. In `ActorEvents_577.init` the owned-pets loop writes each bonus first, choosing `CompanionDB[id][11]` for an upgraded pet. Immediately after, a second loop walks `OptionsListAccount[606]` and unconditionally sets `CompanionBon[id] = CompanionDB[id][2]` — the base value, with no upgraded branch. The upgraded *flag* survives, so a pet in both lists draws a `+` and shows the upgraded buff text while paying its base bonus.

Measured live: pet 46 (`CompanionDB[46]` base `15`, upgraded `25`) returns `25` when only upgraded, `15` when upgraded **and** in `606`.

So the tab keeps the two sets disjoint — marking one clears the other, and `UNLOCK ALL` skips upgraded pets. Since `606` is a saved account value the game and other devices also write, an overlap can still appear on its own; the tab reports it with a one-click fix rather than pretending it cannot happen. Clearing the last upgraded pet turns `w1 companion` off, because an empty list is the default and means *every* pet.

Keeping them disjoint matters for a second reason I could not test: on the Pet Mart map the game strips ids it considers owned out of `606` and rewrites the saved value, and upgraded pets count as owned while the cheat runs. My test account could not reach that map, so that path is read from the bundle rather than measured.

### Two prerequisite fixes

Both are latent bugs today; per-pet selection just makes them unavoidable. They are separate commits so they can be taken on their own.

**`getCompanionInfoMe` replaced the player's companions instead of merging.** Setting `companions` to any non-empty value silently removed every pet the player actually owns from the game's view for as long as the cheat ran. It now calls the original first and merges on id, a configured entry replacing the real one and the rest passing through untouched. The empty-config branch is unchanged, so existing setups behave exactly as before.

**`updateCheatConfig` replaced whole top-level keys.** A partial post dropped a whole branch in the running game — sending only `w1.companion` removed `w1.anvil`, `w1.forge`, `w1.stampcost` and `w1.owl` until restart, and reverted `companion.current`, which `setCompanionFollower` writes in the page and the server copy never learns. `/api/config/update` injects the object it received rather than the merged server copy, so callers cannot avoid this by posting a branch. It now merges recursively, replacing arrays whole so a list can still be shortened.

### Verified against a live game

- Pet 46 went `15` → `25` on the game's own rebuild, and stayed correct across repeated rebuilds with nothing polling.
- Merge holds: `["47,0,0,729,0","46,0,0,0,1","0,0,0,0,1"]` — pet 47 kept with its middle fields, still returning its normal `10`.
- Mutual exclusion: marking a token pet as upgraded emptied `606`; `UNLOCK ALL` wrote 91 ids and skipped every upgraded pet.
- Config survives a partial post: `w1` still had anvil, forge, stampcost, companion, owl, and the page-only `companion.current` stayed put. `/api/toggle` flips rather than sets, so the tab re-reads state first — it stayed on across many writes and off exactly once.
- Injector off: an owned upgraded pet falls back to its real tier, an unowned one gives nothing, token pets keep their base bonus. The selection survives a restart via `config.custom.js`.

`npm run validate` is clean. Also tested on a real Steam install.

### Relationship to #222

#222 solves the same problem by writing `DNSM` directly and repairing it from a 500 ms `setInterval`. The polling is needed there because the game recreates both tables (`new l`) on every map load. Going through the companion list removes the need for a watchdog and lets the game derive the display and tourney values, which direct `DNSM` writes do not. This is per-pet rather than a global toggle, and adds no second cheat.
