### PR TITLE
fix(ui): preserve trailing zeros for integer quantities in formatNumber

### DIFF
--- a/src/ui/utils/numberFormat.js
+++ b/src/ui/utils/numberFormat.js
@@ -18,13 +18,13 @@ export function formatNumber(value) {
     if (n < 0) return "-" + formatNumber(-n);
 
     if (n < 1_000) return n % 1 === 0 ? String(n) : n.toFixed(2);
-    if (n < 1e6) return (n / 1e3).toPrecision(3).replace(/\.?0+$/, "") + "K";
-    if (n < 1e9) return (n / 1e6).toPrecision(3).replace(/\.?0+$/, "") + "M";
-    if (n < 1e12) return (n / 1e9).toPrecision(3).replace(/\.?0+$/, "") + "B";
-    if (n < 1e15) return (n / 1e12).toPrecision(3).replace(/\.?0+$/, "") + "T";
-    if (n < 1e18) return (n / 1e15).toPrecision(3).replace(/\.?0+$/, "") + "Q";
-    if (n < 1e21) return (n / 1e18).toPrecision(3).replace(/\.?0+$/, "") + "QQ";
-    if (n < 1e24) return (n / 1e21).toPrecision(3).replace(/\.?0+$/, "") + "QQQ";
+    if (n < 1e6) return parseFloat((n / 1e3).toPrecision(3)) + "K";
+    if (n < 1e9) return parseFloat((n / 1e6).toPrecision(3)) + "M";
+    if (n < 1e12) return parseFloat((n / 1e9).toPrecision(3)) + "B";
+    if (n < 1e15) return parseFloat((n / 1e12).toPrecision(3)) + "T";
+    if (n < 1e18) return parseFloat((n / 1e15).toPrecision(3)) + "Q";
+    if (n < 1e21) return parseFloat((n / 1e18).toPrecision(3)) + "QQ";
+    if (n < 1e24) return parseFloat((n / 1e21).toPrecision(3)) + "QQQ";
 
     // 1.31E27 style
     const expStr = n.toExponential(2).toUpperCase().replace("E+", "E");


### PR DESCRIPTION
## Summary
Fixes an issue where `formatNumber` stripped trailing zeros from integer multiples of 10 and 100 with magnitude suffixes (e.g. `100M` was formatted as `1M`, `10K` as `1K`, `200B` as `2B`).

## Root cause
The previous regex replacement `.replace(/\.?0+$/, "")` treated the decimal point as optional (`\.?`). When formatting integer results like `(100).toPrecision(3)` (`"100"`), `0+$` matched the integer's trailing zeros rather than decimal zeros.

## Changes
- Replaced `.replace(/\.?0+$/, "")` across all unit thresholds in `src/ui/utils/numberFormat.js` with `parseFloat((...).toPrecision(3))`, which trims trailing decimal zeros without modifying integer digits.
