### PR TITLE
fix(masterclasses): align Royal Armory resource tabs with 10-resource world blocks

### DIFF
--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -11,10 +11,10 @@ const resourceFields = (resourceIds) =>
 const range = (start, end) => Array.from({ length: end - start + 1 }, (_, i) => start + i);
 
 const ROYAL_ARMORY_RESOURCE_TABS = [
-    { id: "w1", label: "W1", fields: resourceFields(range(0, 15)) },
-    { id: "w2", label: "W2", fields: resourceFields(range(20, 36)) },
-    { id: "w3", label: "W3", fields: resourceFields(range(40, 57)) },
-    { id: "w4", label: "W4", fields: resourceFields(range(60, 76)) },
+    { id: "w1", label: "W1", fields: resourceFields(range(0, 9)) },
+    { id: "w2", label: "W2", fields: resourceFields(range(10, 19)) },
+    { id: "w3", label: "W3", fields: resourceFields(range(20, 29)) },
+    { id: "w4", label: "W4", fields: resourceFields(range(30, 39)) },
 ];
 
 export const RoyalArmoryTab = () =>


### PR DESCRIPTION
## Summary
Corrects the `RoyalG[1]` currency indices in `RoyalArmoryTab` so each world tab displays its corresponding 10-resource block (`RGres0..9`, `RGres10..19`, `RGres20..29`, `RGres30..39`).

## Root cause
`ROYAL_ARMORY_RESOURCE_TABS` previously used the physical resource node map indices (`0..15`, `20..36`, `40..57`, `60..76`) instead of the 10-slot currency blocks allocated in `RoyalG[1]`. This placed World 2 resources (`RGres10..15`) into the W1 tab and pointed W3/W4 to unallocated indices.

## Changes
- Updated `ROYAL_ARMORY_RESOURCE_TABS` in `src/ui/components/views/account/masterclasses/RoyalArmoryTab.js` to use `range(0, 9)` for W1, `range(10, 19)` for W2, `range(20, 29)` for W3, and `range(30, 39)` for W4.
