### PR TITLE
feat(masterclasses): support custom display ordering in MasterclassUpgradeTab

### DIFF
--- a/src/ui/components/views/account/masterclasses/MasterclassUpgradeTab.js
+++ b/src/ui/components/views/account/masterclasses/MasterclassUpgradeTab.js
@@ -55,6 +55,7 @@ const resolveStorageIndex = (rawDefinition, definition, index, getStorageIndex) 
 const buildUpgrades = ({
     levels,
     definitions,
+    order = null,
     fallbackPrefix,
     fallbackMax,
     getStorageIndex = null,
@@ -63,21 +64,26 @@ const buildUpgrades = ({
 }) => {
     const levelRows = toIndexedArray(levels ?? []);
     const definitionRows = toIndexedArray(definitions ?? []);
+    const orderRows = order ? toIndexedArray(order).map(Number).filter((n) => Number.isInteger(n) && n >= 0) : null;
     const count =
-        preferDefinitionCount && definitionRows.length
+        orderRows?.length
+            ? orderRows.length
+            : preferDefinitionCount && definitionRows.length
             ? definitionRows.length
             : Math.max(levelRows.length, definitionRows.length);
 
     return Array.from({ length: count }, (_, index) => {
-        const rawDefinition = definitionRows[index];
-        const definition = toIndexedArray(definitionRows[index] ?? []);
-        const storageIndex = resolveStorageIndex(rawDefinition, definition, index, getStorageIndex);
+        const storageIndex = orderRows
+            ? orderRows[index]
+            : resolveStorageIndex(definitionRows[index], toIndexedArray(definitionRows[index] ?? []), index, getStorageIndex);
+        const rawDefinition = definitionRows[storageIndex];
+        const definition = toIndexedArray(rawDefinition ?? []);
         const rawName = definition[0];
         const maxLevel =
             maxLevelIndex !== null && maxLevelIndex !== undefined
                 ? firstFiniteNumber([definition[maxLevelIndex]], fallbackMax)
                 : firstFiniteNumber([definition[4], definition[3], definition[2]], fallbackMax);
-        const displayIndex = storageIndex === index ? `#${index}` : `#${storageIndex}`;
+        const displayIndex = `#${index + 1}`;
 
         return {
             index,
@@ -225,6 +231,7 @@ export const MasterclassUpgradeTab = ({
     description,
     levelsPath,
     definitionPaths,
+    orderPath = null,
     fallbackPrefix,
     fallbackMax = 999999,
     getStorageIndex = null,
@@ -288,10 +295,11 @@ export const MasterclassUpgradeTab = ({
 
     const load = () =>
         runLoad(async () => {
-            const [rawLevels, definitionTable, rawCurrencyValues] = await Promise.all([
+            const [rawLevels, definitionTable, rawCurrencyValues, rawOrder] = await Promise.all([
                 gga(levelsPath),
                 staticUpgrades?.length ? Promise.resolve({ path: null, rows: [] }) : readFirstDefinitionTable(definitionPaths),
                 Promise.all(allCurrencyFields.map((field) => gga(fieldPath(field)))),
+                orderPath ? readCList(orderPath) : Promise.resolve(null),
             ]);
             const levels = toIndexedArray(rawLevels ?? []);
             const nextUpgrades = staticUpgrades?.length
@@ -299,6 +307,7 @@ export const MasterclassUpgradeTab = ({
                 : buildUpgrades({
                       levels,
                       definitions: definitionTable.rows,
+                      order: rawOrder,
                       fallbackPrefix,
                       fallbackMax,
                       getStorageIndex,

--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -23,6 +23,7 @@ export const RoyalArmoryTab = () =>
         description: "Manage Royal Guard Royal Armory upgrades.",
         levelsPath: "RoyalG[2]",
         definitionPaths: ["ArmoryUpg"],
+        orderPath: "Research[43]",
         currencyTitle: "ROYAL RESOURCES",
         currencyTabs: ROYAL_ARMORY_RESOURCE_TABS,
         fallbackPrefix: "Royal Armory Upgrade",


### PR DESCRIPTION
## Summary
Adds `orderPath` support to `MasterclassUpgradeTab` and applies the in-game Royal Armory display order from `cList.Research[43]`.

## Changes
- `MasterclassUpgradeTab.js`: Added `orderPath` support to load and render upgrade rows in game-defined order while targeting their original storage indices in `RoyalG[2]`.
- `RoyalArmoryTab.js`: Specified `orderPath: "Research[43]"` to render the 69 active upgrades in game order.
