### PR TITLE
feat(cheats): add ban_a through ban_i bundles to knownBundles

### DIFF
--- a/src/cheats/constants.js
+++ b/src/cheats/constants.js
@@ -216,6 +216,15 @@ export const knownBundles = [
     ["Sweet And Lovely Pack", "bon_t"],
     ["Pot Of Gold Pack", "bon_u"],
     ["Kelp N Roll Pack", "bon_v"],
+    ["5th Birthday Bundle", "ban_a"],
+    ["Time Traveler Pack", "ban_b"],
+    ["Yolkmaster Pack", "ban_c"],
+    ["The Spooky Pack", "ban_d"],
+    ["Crystalline Glunko Pack", "ban_e"],
+    ["Paradise Pack", "ban_f"],
+    ["Armadillius Superius Pack", "ban_g"],
+    ["Coral Guardian Pack", "ban_h"],
+    ["Daydreamer Pack", "ban_i"],
 ];
 
 // Item types to exclude from bulk commands (invalid or problematic types)


### PR DESCRIPTION
## Summary

Add the `ban_a` through `ban_i` gem shop bundles to `knownBundles`.

- `ban_a`: 5th Birthday Bundle
- `ban_b`: Time Traveler Pack
- `ban_c`: Yolkmaster Pack
- `ban_d`: The Spooky Pack
- `ban_e`: Crystalline Glunko Pack
- `ban_f`: Paradise Pack
- `ban_g`: Armadillius Superius Pack
- `ban_h`: Coral Guardian Pack
- `ban_i`: Daydreamer Pack
