### PR TITLE
Rebuild Royal Guard units after Armory changes

### DIFF
--- a/src/ui/components/views/account/masterclasses/MasterclassUpgradeTab.js
+++ b/src/ui/components/views/account/masterclasses/MasterclassUpgradeTab.js
@@ -65,18 +65,26 @@ const buildUpgrades = ({
 }) => {
     const levelRows = toIndexedArray(levels ?? []);
     const definitionRows = toIndexedArray(definitions ?? []);
-    const orderRows = order ? toIndexedArray(order).map(Number).filter((n) => Number.isInteger(n) && n >= 0) : null;
-    const count =
-        orderRows?.length
-            ? orderRows.length
-            : preferDefinitionCount && definitionRows.length
-            ? definitionRows.length
-            : Math.max(levelRows.length, definitionRows.length);
+    const orderRows = order
+        ? toIndexedArray(order)
+              .map(Number)
+              .filter((n) => Number.isInteger(n) && n >= 0)
+        : null;
+    const count = orderRows?.length
+        ? orderRows.length
+        : preferDefinitionCount && definitionRows.length
+          ? definitionRows.length
+          : Math.max(levelRows.length, definitionRows.length);
 
     return Array.from({ length: count }, (_, index) => {
         const storageIndex = orderRows
             ? orderRows[index]
-            : resolveStorageIndex(definitionRows[index], toIndexedArray(definitionRows[index] ?? []), index, getStorageIndex);
+            : resolveStorageIndex(
+                  definitionRows[index],
+                  toIndexedArray(definitionRows[index] ?? []),
+                  index,
+                  getStorageIndex
+              );
         const rawDefinition = definitionRows[storageIndex];
         const definition = toIndexedArray(rawDefinition ?? []);
         const rawName = definition[0];
@@ -129,7 +137,7 @@ const matchesSearch = (upgrade, query) => {
     );
 };
 
-const UpgradeRow = ({ levelsPath, upgrade, levelState, deleteCachePaths = [] }) =>
+const UpgradeRow = ({ levelsPath, upgrade, levelState, deleteCachePaths = [], onChanged = null }) =>
     ClampedLevelRow({
         valueState: levelState,
         max: upgrade.maxLevel,
@@ -139,16 +147,21 @@ const UpgradeRow = ({ levelsPath, upgrade, levelState, deleteCachePaths = [] }) 
             value: upgrade.maxLevel,
             tooltip: `Set ${upgrade.name} to level ${upgrade.maxLevel}`,
         },
-        writePath: deleteCachePaths.length ? null : `${levelsPath}[${upgrade.storageIndex}]`,
-        write: deleteCachePaths.length
-            ? async (nextLevel) => {
-                  await writeVerified(`${levelsPath}[${upgrade.storageIndex}]`, nextLevel);
-                  for (const cachePath of deleteCachePaths) {
-                      await deleteGga(cachePath);
+        writePath:
+            deleteCachePaths.length || typeof onChanged === "function"
+                ? null
+                : `${levelsPath}[${upgrade.storageIndex}]`,
+        write:
+            deleteCachePaths.length || typeof onChanged === "function"
+                ? async (nextLevel) => {
+                      await writeVerified(`${levelsPath}[${upgrade.storageIndex}]`, nextLevel);
+                      for (const cachePath of deleteCachePaths) {
+                          await deleteGga(cachePath);
+                      }
+                      if (typeof onChanged === "function") await onChanged({ upgrade, nextLevel });
+                      return nextLevel;
                   }
-                  return nextLevel;
-              }
-            : null,
+                : null,
         renderInfo: () => [
             span({ class: "account-row__index" }, upgrade.displayIndex),
             span({ class: "account-row__name" }, upgrade.name),
@@ -162,25 +175,22 @@ const UpgradeRow = ({ levelsPath, upgrade, levelState, deleteCachePaths = [] }) 
 
 const fieldPath = (field) => field.path ?? `OptionsListAccount[${field.optionIndex}]`;
 
-const flattenCurrencyFields = (fields, tabs) => [
-    ...fields,
-    ...tabs.flatMap((tab) => tab.fields ?? []),
-];
+const flattenCurrencyFields = (fields, tabs) => [...fields, ...tabs.flatMap((tab) => tab.fields ?? [])];
 
 const FieldLabel = (field) =>
     field.badge
         ? [span({ class: "masterclass-currency__badge" }, field.badge), field.name]
         : field.iconUrl
-        ? [
-              img({
-                  class: "masterclass-currency__icon",
-                  src: field.iconUrl,
-                  alt: "",
-                  loading: "lazy",
-              }),
-              field.name,
-          ]
-        : field.name;
+          ? [
+                img({
+                    class: "masterclass-currency__icon",
+                    src: field.iconUrl,
+                    alt: "",
+                    loading: "lazy",
+                }),
+                field.name,
+            ]
+          : field.name;
 
 const renderCurrencyField = (field, states) =>
     field.type === "toggle"
@@ -246,9 +256,7 @@ const CurrencySection = ({ title, fields, states, tabs = [], activeTab = null })
                         {
                             type: "button",
                             class: () =>
-                                `masterclass-category-tabs__button${
-                                    activeTab.val === tab.id ? " is-active" : ""
-                                }`,
+                                `masterclass-category-tabs__button${activeTab.val === tab.id ? " is-active" : ""}`,
                             onclick: () => {
                                 activeTab.val = tab.id;
                             },
@@ -278,6 +286,8 @@ export const MasterclassUpgradeTab = ({
     currencyFields = [],
     currencyTabs = [],
     deleteCachePaths = [],
+    onUpgradeChanged = null,
+    onBulkChanged = null,
 }) => {
     const { loading, error, run: runLoad } = useAccountLoad({ label: title });
     const { status: bulkStatus, run: runBulk } = useWriteStatus();
@@ -320,6 +330,7 @@ export const MasterclassUpgradeTab = ({
                     upgrade,
                     levelState: getOrCreateState(levelStates, upgrade.index),
                     deleteCachePaths,
+                    onChanged: onUpgradeChanged,
                 })
             );
         });
@@ -335,7 +346,9 @@ export const MasterclassUpgradeTab = ({
         runLoad(async () => {
             const [rawLevels, definitionTable, rawCurrencyValues, rawOrder] = await Promise.all([
                 gga(levelsPath),
-                staticUpgrades?.length ? Promise.resolve({ path: null, rows: [] }) : readFirstDefinitionTable(definitionPaths),
+                staticUpgrades?.length
+                    ? Promise.resolve({ path: null, rows: [] })
+                    : readFirstDefinitionTable(definitionPaths),
                 Promise.all(allCurrencyFields.map((field) => gga(fieldPath(field)))),
                 orderPath ? readCList(orderPath) : Promise.resolve(null),
             ]);
@@ -378,13 +391,13 @@ export const MasterclassUpgradeTab = ({
                     getValueState: (upgrade) => getOrCreateState(levelStates, upgrade.index),
                     getPath: (upgrade) => `${levelsPath}[${upgrade.storageIndex}]`,
                 });
+                if (typeof onBulkChanged === "function") await onBulkChanged({ upgrades: currentUpgrades, mode });
             } finally {
                 for (const cachePath of deleteCachePaths) {
                     await deleteGga(cachePath);
                 }
             }
         });
-
         if (!result.ok) await load();
     };
 

--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -95,7 +95,7 @@ const DEFAULT_UNIT_COUNTS = {
     7: 1,
 };
 
-const VANILLA_MILITIA_SHELVES = {
+export const MILITIA_SHELF_TO_WORLD = {
     1: 14,
     2: 19,
     3: 38,
@@ -118,12 +118,6 @@ const VANILLA_UNIT_HOME_MAPS = {
 
 const SOVEREIGNTY_SHELF = 28;
 const SOVEREIGNTY_UPGRADE_ID = 68;
-export const ROYAL_GUARD_VANILLA_UNIT_UPGRADES = new Set([
-    ...Object.values(VANILLA_MILITIA_SHELVES),
-    ...Object.values(VANILLA_MILITIA_UPGRADES),
-    SOVEREIGNTY_SHELF,
-    SOVEREIGNTY_UPGRADE_ID,
-]);
 const SOVEREIGNTY_UNIT_TYPES = "0,0,0,0,0,0,0,1,1,1,1,1,1,0,0,0,1,1,1,1,0,2,2,2,1,2,2,2,2,2,2,2,0,1,2,2"
     .split(",")
     .map((value) => Number(value) + 5);
@@ -248,14 +242,14 @@ const makeUnitSummary = ({ world, types, addedNew = 0, movedExisting = 0 }) => (
     movedExisting,
 });
 
-const buildVanillaUnitArrays = (royalG, order = [], world = null) => {
+const buildVanillaUnitArrays = (royalG, order = []) => {
     const upgrades = toIndexedArray(royalG?.[2] ?? []);
     const resolveUpgradeId = (shelf, fallback) => {
         const resolved = Number(toIndexedArray(order)[shelf]);
         return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
     };
     const militiaUpgrades = Object.fromEntries(
-        Object.entries(VANILLA_MILITIA_SHELVES).map(([worldKey, shelf]) => [
+        Object.entries(MILITIA_SHELF_TO_WORLD).map(([worldKey, shelf]) => [
             worldKey,
             resolveUpgradeId(shelf, VANILLA_MILITIA_UPGRADES[worldKey]),
         ])
@@ -266,7 +260,6 @@ const buildVanillaUnitArrays = (royalG, order = [], world = null) => {
 
     Object.entries(MAP_UNIT_ARRAYS).forEach(([worldKey, arrays]) => {
         const currentWorld = Number(worldKey);
-        if (world !== null && currentWorld !== world) return;
         const types = [];
         const maps = [];
         const homeMap = VANILLA_UNIT_HOME_MAPS[currentWorld];
@@ -306,7 +299,98 @@ export const refreshRoyalGuardUnitCaches = async () => {
     await deleteGga("DNSM.h.TotUnitzAllMapz");
 };
 
-export const rebuildRoyalGuardVanillaUnits = async ({ world = null } = {}) => {
+const resolveArmoryUpgradeId = (order, shelf, fallback) => {
+    const resolved = Number(toIndexedArray(order)[shelf]);
+    return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
+};
+
+export const syncRoyalGuardMilitiaForWorld = async (world) => {
+    const arrays = MAP_UNIT_ARRAYS[world];
+    const shelf = Object.entries(MILITIA_SHELF_TO_WORLD).find(([, value]) => value === Number(world))?.[0];
+    if (!arrays || !shelf) return;
+
+    const [rawRoyalG, rawOrder] = await Promise.all([gga("RoyalG"), readCList("Research[43]")]);
+    const royalG = toIndexedArray(rawRoyalG ?? []);
+    const upgradeId = resolveArmoryUpgradeId(rawOrder, Number(shelf), VANILLA_MILITIA_UPGRADES[world]);
+    const wantedCount = Math.max(0, Math.min(10, toInt(royalG[2]?.[upgradeId], { min: 0, mode: "floor" })));
+    const types = toIndexedArray(royalG[arrays.typeArray] ?? []).slice();
+    const maps = toIndexedArray(royalG[arrays.mapArray] ?? []).slice();
+    const militiaIndexes = [];
+    for (let index = 0; index < Math.min(types.length, maps.length); index++) {
+        if (Number(types[index]) === 4) militiaIndexes.push(index);
+    }
+
+    while (militiaIndexes.length > wantedCount) {
+        const index = militiaIndexes.pop();
+        types.splice(index, 1);
+        maps.splice(index, 1);
+    }
+
+    while (militiaIndexes.length < wantedCount) {
+        types.push(4);
+        maps.push(VANILLA_UNIT_HOME_MAPS[world]);
+        militiaIndexes.push(types.length - 1);
+    }
+
+    await writeManyVerified([
+        { path: `RoyalG[${arrays.typeArray}]`, value: types },
+        { path: `RoyalG[${arrays.mapArray}]`, value: maps },
+    ]);
+    await refreshRoyalGuardUnitCaches();
+};
+
+export const syncRoyalGuardSovereigntyUnits = async () => {
+    const [rawRoyalG, rawOrder] = await Promise.all([gga("RoyalG"), readCList("Research[43]")]);
+    const royalG = toIndexedArray(rawRoyalG ?? []);
+    const upgradeId = resolveArmoryUpgradeId(rawOrder, SOVEREIGNTY_SHELF, SOVEREIGNTY_UPGRADE_ID);
+    const wantedCount = Math.max(
+        0,
+        Math.min(SOVEREIGNTY_UNIT_TYPES.length, toInt(royalG[2]?.[upgradeId], { min: 0, mode: "floor" }))
+    );
+    const wantedByWorld = {};
+    for (let index = 0; index < wantedCount; index++) {
+        const world = Number(SOVEREIGNTY_WORLDS[index]);
+        const type = SOVEREIGNTY_UNIT_TYPES[index];
+        wantedByWorld[world] ??= {};
+        wantedByWorld[world][type] = (wantedByWorld[world][type] ?? 0) + 1;
+    }
+
+    const writes = [];
+    Object.entries(MAP_UNIT_ARRAYS).forEach(([worldKey, arrays]) => {
+        const world = Number(worldKey);
+        const types = toIndexedArray(royalG[arrays.typeArray] ?? []).slice();
+        const maps = toIndexedArray(royalG[arrays.mapArray] ?? []).slice();
+        const kept = [];
+        const currentVanilla = {};
+        for (let index = 0; index < Math.min(types.length, maps.length); index++) {
+            const type = Number(types[index]);
+            const isHomeUnit = type >= 5 && type <= 7 && Number(maps[index]) === VANILLA_UNIT_HOME_MAPS[world];
+            const wanted = wantedByWorld[world]?.[type] ?? 0;
+            if (isHomeUnit && (currentVanilla[type] ?? 0) >= wanted) continue;
+            if (isHomeUnit) currentVanilla[type] = (currentVanilla[type] ?? 0) + 1;
+            kept.push([types[index], maps[index]]);
+        }
+
+        Object.entries(wantedByWorld[world] ?? {}).forEach(([type, count]) => {
+            for (let index = currentVanilla[type] ?? 0; index < count; index++)
+                kept.push([Number(type), VANILLA_UNIT_HOME_MAPS[world]]);
+        });
+
+        writes.push({
+            path: `RoyalG[${arrays.typeArray}]`,
+            value: kept.map(([type]) => type),
+        });
+        writes.push({
+            path: `RoyalG[${arrays.mapArray}]`,
+            value: kept.map(([, map]) => map),
+        });
+    });
+
+    await writeManyVerified(writes);
+    await refreshRoyalGuardUnitCaches();
+};
+
+export const resetRoyalGuardUnitsToVanilla = async () => {
     const [rawRoyalG, rawRoyalMaps, rawOrder] = await Promise.all([
         gga("RoyalG"),
         gga("RoyalMaps"),
@@ -314,8 +398,7 @@ export const rebuildRoyalGuardVanillaUnits = async ({ world = null } = {}) => {
     ]);
     const royalG = toIndexedArray(rawRoyalG ?? []);
     const royalMaps = toIndexedArray(rawRoyalMaps ?? []);
-    const selectedWorld = world === null || world === undefined ? null : Number(world);
-    const { rebuilt } = buildVanillaUnitArrays(royalG, rawOrder, selectedWorld);
+    const { rebuilt } = buildVanillaUnitArrays(royalG, rawOrder);
     const writes = [];
 
     Object.values(rebuilt).forEach((entry) => {
@@ -325,7 +408,6 @@ export const rebuildRoyalGuardVanillaUnits = async ({ world = null } = {}) => {
 
     royalMaps.forEach((row, mapId) => {
         if (!Array.isArray(row) || row.length < BUILT_OUTPOST_LENGTH) return;
-        if (selectedWorld !== null && worldFromMapId(mapId) !== selectedWorld) return;
         const nextSlots = normalizeSlotsForCapacity(row[11], row[0], row[12]);
         if (nextSlots !== row[11]) writes.push({ path: `RoyalMaps[${mapId}][11]`, value: nextSlots });
     });
@@ -640,7 +722,7 @@ const UnitBulkPanel = ({ royalGState, onChanged, outpostsByWorld, mapDispNames, 
                     onClick: (e) => {
                         e.preventDefault();
                         void vanillaStatus.run(async () => {
-                            await rebuildRoyalGuardVanillaUnits();
+                            await resetRoyalGuardUnitsToVanilla();
                             if (typeof onChanged === "function") await onChanged();
                         });
                     },

--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -95,7 +95,7 @@ const DEFAULT_UNIT_COUNTS = {
     7: 1,
 };
 
-export const MILITIA_WORLD_TO_SHELF = {
+export const MILITIA_WORLD_TO_DISPLAY_SHELF = {
     1: 14,
     2: 19,
     3: 38,
@@ -107,7 +107,8 @@ export const MILITIA_SHELF_TO_WORLD = {
     38: 3,
     56: 4,
 };
-export const UNIT_REBUILD_SHELVES = new Set([14, 19, 28, 38, 56]);
+export const UNIT_REBUILD_DISPLAY_SHELVES = new Set([14, 19, 28, 38, 56]);
+const displayShelfToOrderIndex = (displayShelf) => displayShelf - 1;
 
 const VANILLA_MILITIA_UPGRADES = {
     1: 60,
@@ -256,12 +257,12 @@ const buildVanillaUnitArrays = (royalG, order = []) => {
         return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
     };
     const militiaUpgrades = Object.fromEntries(
-        Object.entries(MILITIA_WORLD_TO_SHELF).map(([worldKey, shelf]) => [
+        Object.entries(MILITIA_WORLD_TO_DISPLAY_SHELF).map(([worldKey, displayShelf]) => [
             worldKey,
-            resolveUpgradeId(shelf, VANILLA_MILITIA_UPGRADES[worldKey]),
+            resolveUpgradeId(displayShelfToOrderIndex(displayShelf), VANILLA_MILITIA_UPGRADES[worldKey]),
         ])
     );
-    const sovereigntyUpgrade = resolveUpgradeId(SOVEREIGNTY_SHELF, SOVEREIGNTY_UPGRADE_ID);
+    const sovereigntyUpgrade = resolveUpgradeId(displayShelfToOrderIndex(SOVEREIGNTY_SHELF), SOVEREIGNTY_UPGRADE_ID);
     const rebuilt = {};
     const summaries = [];
 

--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -95,12 +95,19 @@ const DEFAULT_UNIT_COUNTS = {
     7: 1,
 };
 
-export const MILITIA_SHELF_TO_WORLD = {
+export const MILITIA_WORLD_TO_SHELF = {
     1: 14,
     2: 19,
     3: 38,
     4: 56,
 };
+export const MILITIA_SHELF_TO_WORLD = {
+    14: 1,
+    19: 2,
+    38: 3,
+    56: 4,
+};
+export const UNIT_REBUILD_SHELVES = new Set([14, 19, 28, 38, 56]);
 
 const VANILLA_MILITIA_UPGRADES = {
     1: 60,
@@ -249,7 +256,7 @@ const buildVanillaUnitArrays = (royalG, order = []) => {
         return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
     };
     const militiaUpgrades = Object.fromEntries(
-        Object.entries(MILITIA_SHELF_TO_WORLD).map(([worldKey, shelf]) => [
+        Object.entries(MILITIA_WORLD_TO_SHELF).map(([worldKey, shelf]) => [
             worldKey,
             resolveUpgradeId(shelf, VANILLA_MILITIA_UPGRADES[worldKey]),
         ])
@@ -297,97 +304,6 @@ const buildVanillaUnitArrays = (royalG, order = []) => {
 
 export const refreshRoyalGuardUnitCaches = async () => {
     await deleteGga("DNSM.h.TotUnitzAllMapz");
-};
-
-const resolveArmoryUpgradeId = (order, shelf, fallback) => {
-    const resolved = Number(toIndexedArray(order)[shelf]);
-    return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
-};
-
-export const syncRoyalGuardMilitiaForWorld = async (world) => {
-    const arrays = MAP_UNIT_ARRAYS[world];
-    const shelf = Object.entries(MILITIA_SHELF_TO_WORLD).find(([, value]) => value === Number(world))?.[0];
-    if (!arrays || !shelf) return;
-
-    const [rawRoyalG, rawOrder] = await Promise.all([gga("RoyalG"), readCList("Research[43]")]);
-    const royalG = toIndexedArray(rawRoyalG ?? []);
-    const upgradeId = resolveArmoryUpgradeId(rawOrder, Number(shelf), VANILLA_MILITIA_UPGRADES[world]);
-    const wantedCount = Math.max(0, Math.min(10, toInt(royalG[2]?.[upgradeId], { min: 0, mode: "floor" })));
-    const types = toIndexedArray(royalG[arrays.typeArray] ?? []).slice();
-    const maps = toIndexedArray(royalG[arrays.mapArray] ?? []).slice();
-    const militiaIndexes = [];
-    for (let index = 0; index < Math.min(types.length, maps.length); index++) {
-        if (Number(types[index]) === 4) militiaIndexes.push(index);
-    }
-
-    while (militiaIndexes.length > wantedCount) {
-        const index = militiaIndexes.pop();
-        types.splice(index, 1);
-        maps.splice(index, 1);
-    }
-
-    while (militiaIndexes.length < wantedCount) {
-        types.push(4);
-        maps.push(VANILLA_UNIT_HOME_MAPS[world]);
-        militiaIndexes.push(types.length - 1);
-    }
-
-    await writeManyVerified([
-        { path: `RoyalG[${arrays.typeArray}]`, value: types },
-        { path: `RoyalG[${arrays.mapArray}]`, value: maps },
-    ]);
-    await refreshRoyalGuardUnitCaches();
-};
-
-export const syncRoyalGuardSovereigntyUnits = async () => {
-    const [rawRoyalG, rawOrder] = await Promise.all([gga("RoyalG"), readCList("Research[43]")]);
-    const royalG = toIndexedArray(rawRoyalG ?? []);
-    const upgradeId = resolveArmoryUpgradeId(rawOrder, SOVEREIGNTY_SHELF, SOVEREIGNTY_UPGRADE_ID);
-    const wantedCount = Math.max(
-        0,
-        Math.min(SOVEREIGNTY_UNIT_TYPES.length, toInt(royalG[2]?.[upgradeId], { min: 0, mode: "floor" }))
-    );
-    const wantedByWorld = {};
-    for (let index = 0; index < wantedCount; index++) {
-        const world = Number(SOVEREIGNTY_WORLDS[index]);
-        const type = SOVEREIGNTY_UNIT_TYPES[index];
-        wantedByWorld[world] ??= {};
-        wantedByWorld[world][type] = (wantedByWorld[world][type] ?? 0) + 1;
-    }
-
-    const writes = [];
-    Object.entries(MAP_UNIT_ARRAYS).forEach(([worldKey, arrays]) => {
-        const world = Number(worldKey);
-        const types = toIndexedArray(royalG[arrays.typeArray] ?? []).slice();
-        const maps = toIndexedArray(royalG[arrays.mapArray] ?? []).slice();
-        const kept = [];
-        const currentVanilla = {};
-        for (let index = 0; index < Math.min(types.length, maps.length); index++) {
-            const type = Number(types[index]);
-            const isHomeUnit = type >= 5 && type <= 7 && Number(maps[index]) === VANILLA_UNIT_HOME_MAPS[world];
-            const wanted = wantedByWorld[world]?.[type] ?? 0;
-            if (isHomeUnit && (currentVanilla[type] ?? 0) >= wanted) continue;
-            if (isHomeUnit) currentVanilla[type] = (currentVanilla[type] ?? 0) + 1;
-            kept.push([types[index], maps[index]]);
-        }
-
-        Object.entries(wantedByWorld[world] ?? {}).forEach(([type, count]) => {
-            for (let index = currentVanilla[type] ?? 0; index < count; index++)
-                kept.push([Number(type), VANILLA_UNIT_HOME_MAPS[world]]);
-        });
-
-        writes.push({
-            path: `RoyalG[${arrays.typeArray}]`,
-            value: kept.map(([type]) => type),
-        });
-        writes.push({
-            path: `RoyalG[${arrays.mapArray}]`,
-            value: kept.map(([, map]) => map),
-        });
-    });
-
-    await writeManyVerified(writes);
-    await refreshRoyalGuardUnitCaches();
 };
 
 export const resetRoyalGuardUnitsToVanilla = async () => {

--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -1,7 +1,7 @@
 import van from "../../../../vendor/van-1.6.0.js";
 import { EmptyState } from "../../../EmptyState.js";
 import { Icons } from "../../../../assets/icons.js";
-import { gga, readCList } from "../../../../services/api.js";
+import { deleteGga, gga, readCList } from "../../../../services/api.js";
 import { formatNumber } from "../../../../utils/numberFormat.js";
 import { toIndexedArray } from "../../../../utils/index.js";
 import { BulkActionBar } from "../BulkActionBar.js";
@@ -95,6 +95,13 @@ const DEFAULT_UNIT_COUNTS = {
     7: 1,
 };
 
+const VANILLA_MILITIA_SHELVES = {
+    1: 14,
+    2: 19,
+    3: 38,
+    4: 56,
+};
+
 const VANILLA_MILITIA_UPGRADES = {
     1: 60,
     2: 61,
@@ -109,12 +116,18 @@ const VANILLA_UNIT_HOME_MAPS = {
     4: 151,
 };
 
+const SOVEREIGNTY_SHELF = 28;
 const SOVEREIGNTY_UPGRADE_ID = 68;
+export const ROYAL_GUARD_VANILLA_UNIT_UPGRADES = new Set([
+    ...Object.values(VANILLA_MILITIA_SHELVES),
+    ...Object.values(VANILLA_MILITIA_UPGRADES),
+    SOVEREIGNTY_SHELF,
+    SOVEREIGNTY_UPGRADE_ID,
+]);
 const SOVEREIGNTY_UNIT_TYPES = "0,0,0,0,0,0,0,1,1,1,1,1,1,0,0,0,1,1,1,1,0,2,2,2,1,2,2,2,2,2,2,2,0,1,2,2"
     .split(",")
     .map((value) => Number(value) + 5);
-const SOVEREIGNTY_WORLDS = "1,2,1,2,1,2,3,1,2,3,1,2,3,3,4,3,4,1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,4,4,4"
-    .split(",")
+const SOVEREIGNTY_WORLDS = "1,2,1,2,1,2,3,1,2,3,1,2,3,3,4,3,4,1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,4,4,4".split(",");
 const formatAmount = (value) => formatNumber(Math.max(0, Math.floor(toNum(value, 0))));
 const rankFieldIndex = (field) => field.index - 3;
 
@@ -139,10 +152,17 @@ const getOutpostRankInfo = (xp, rankType) => {
 const selectOption = ({ value, label }, current) =>
     option({ value: String(value), selected: String(value) === String(current) }, label);
 
-const decodeSlots = (value) => String(Math.trunc(toNum(value, 111111111))).padStart(9, "1").slice(-9).split("");
+const decodeSlots = (value) =>
+    String(Math.trunc(toNum(value, 111111111)))
+        .padStart(9, "1")
+        .slice(-9)
+        .split("");
 const encodeSlots = (slots) => Number(slots.join(""));
 const unlockedSlotCount = (barracksLevel, glorified) =>
-    Math.max(0, Math.min(9, 1 + Math.min(5, toInt(barracksLevel, { min: 0, mode: "floor" })) + (toInt(glorified) === 1 ? 1 : 0)));
+    Math.max(
+        0,
+        Math.min(9, 1 + Math.min(5, toInt(barracksLevel, { min: 0, mode: "floor" })) + (toInt(glorified) === 1 ? 1 : 0))
+    );
 
 const outpostTypeLabel = (type) =>
     OUTPOST_TYPES.find((entry) => entry.value === Number(type))?.label ?? `Outpost Type ${type}`;
@@ -211,7 +231,8 @@ const rowKind = (row) => {
     return "hidden";
 };
 
-const getUnitTypeLabel = (type) => MAP_UNIT_TYPES.find((entry) => entry.value === Number(type))?.label ?? `Unit ${type}`;
+const getUnitTypeLabel = (type) =>
+    MAP_UNIT_TYPES.find((entry) => entry.value === Number(type))?.label ?? `Unit ${type}`;
 
 const countUnitTypes = (types) =>
     types.reduce((acc, type) => {
@@ -227,17 +248,29 @@ const makeUnitSummary = ({ world, types, addedNew = 0, movedExisting = 0 }) => (
     movedExisting,
 });
 
-const buildVanillaUnitArrays = (royalG) => {
+const buildVanillaUnitArrays = (royalG, order = [], world = null) => {
     const upgrades = toIndexedArray(royalG?.[2] ?? []);
+    const resolveUpgradeId = (shelf, fallback) => {
+        const resolved = Number(toIndexedArray(order)[shelf]);
+        return Number.isInteger(resolved) && resolved >= 0 ? resolved : fallback;
+    };
+    const militiaUpgrades = Object.fromEntries(
+        Object.entries(VANILLA_MILITIA_SHELVES).map(([worldKey, shelf]) => [
+            worldKey,
+            resolveUpgradeId(shelf, VANILLA_MILITIA_UPGRADES[worldKey]),
+        ])
+    );
+    const sovereigntyUpgrade = resolveUpgradeId(SOVEREIGNTY_SHELF, SOVEREIGNTY_UPGRADE_ID);
     const rebuilt = {};
     const summaries = [];
 
     Object.entries(MAP_UNIT_ARRAYS).forEach(([worldKey, arrays]) => {
-        const world = Number(worldKey);
+        const currentWorld = Number(worldKey);
+        if (world !== null && currentWorld !== world) return;
         const types = [];
         const maps = [];
-        const homeMap = VANILLA_UNIT_HOME_MAPS[world];
-        const militiaUpgrade = VANILLA_MILITIA_UPGRADES[world];
+        const homeMap = VANILLA_UNIT_HOME_MAPS[currentWorld];
+        const militiaUpgrade = militiaUpgrades[currentWorld];
         const militiaCount = Math.max(0, Math.min(10, toInt(upgrades[militiaUpgrade], { min: 0, mode: "floor" })));
 
         for (let i = 0; i < militiaCount; i++) {
@@ -245,21 +278,21 @@ const buildVanillaUnitArrays = (royalG) => {
             maps.push(homeMap);
         }
 
-        rebuilt[world] = { ...arrays, types, maps };
+        rebuilt[currentWorld] = { ...arrays, types, maps };
     });
 
     const sovereigntyCount = Math.max(
         0,
-        Math.min(SOVEREIGNTY_UNIT_TYPES.length, toInt(upgrades[SOVEREIGNTY_UPGRADE_ID], { min: 0, mode: "floor" }))
+        Math.min(SOVEREIGNTY_UNIT_TYPES.length, toInt(upgrades[sovereigntyUpgrade], { min: 0, mode: "floor" }))
     );
 
     for (let index = 0; index < sovereigntyCount; index++) {
-        const world = SOVEREIGNTY_WORLDS[index];
-        const target = rebuilt[world];
+        const currentWorld = Number(SOVEREIGNTY_WORLDS[index]);
+        const target = rebuilt[currentWorld];
         if (!target) continue;
 
         target.types.push(SOVEREIGNTY_UNIT_TYPES[index]);
-        target.maps.push(VANILLA_UNIT_HOME_MAPS[world]);
+        target.maps.push(VANILLA_UNIT_HOME_MAPS[currentWorld]);
     }
 
     Object.entries(rebuilt).forEach(([worldKey, entry]) => {
@@ -267,6 +300,38 @@ const buildVanillaUnitArrays = (royalG) => {
     });
 
     return { rebuilt, summaries, sovereigntyCount };
+};
+
+export const refreshRoyalGuardUnitCaches = async () => {
+    await deleteGga("DNSM.h.TotUnitzAllMapz");
+};
+
+export const rebuildRoyalGuardVanillaUnits = async ({ world = null } = {}) => {
+    const [rawRoyalG, rawRoyalMaps, rawOrder] = await Promise.all([
+        gga("RoyalG"),
+        gga("RoyalMaps"),
+        readCList("Research[43]"),
+    ]);
+    const royalG = toIndexedArray(rawRoyalG ?? []);
+    const royalMaps = toIndexedArray(rawRoyalMaps ?? []);
+    const selectedWorld = world === null || world === undefined ? null : Number(world);
+    const { rebuilt } = buildVanillaUnitArrays(royalG, rawOrder, selectedWorld);
+    const writes = [];
+
+    Object.values(rebuilt).forEach((entry) => {
+        writes.push({ path: `RoyalG[${entry.typeArray}]`, value: entry.types });
+        writes.push({ path: `RoyalG[${entry.mapArray}]`, value: entry.maps });
+    });
+
+    royalMaps.forEach((row, mapId) => {
+        if (!Array.isArray(row) || row.length < BUILT_OUTPOST_LENGTH) return;
+        if (selectedWorld !== null && worldFromMapId(mapId) !== selectedWorld) return;
+        const nextSlots = normalizeSlotsForCapacity(row[11], row[0], row[12]);
+        if (nextSlots !== row[11]) writes.push({ path: `RoyalMaps[${mapId}][11]`, value: nextSlots });
+    });
+
+    await writeManyVerified(writes);
+    await refreshRoyalGuardUnitCaches();
 };
 
 const buildDistributedUnitArrays = (royalG, wantedPerOutpost, outpostsByWorld) => {
@@ -361,7 +426,7 @@ const OutpostSlots = ({ mapId, slotState, barracksState, glorifiedState }) => {
                     class: () =>
                         `outpost-slot-select${status.val === "success" ? " is-success" : ""}${
                             status.val === "error" ? " is-error" : ""
-                    }`,
+                        }`,
                     value: () => slots()[slot],
                     title: `Slot ${slot + 1}`,
                     disabled: () => slot >= unlockedSlots(),
@@ -386,7 +451,8 @@ const MapUnitAddControl = ({ outpost, onAdded }) => {
     const typeState = van.state(MAP_UNIT_TYPES[0].value);
     const { status, run } = useWriteStatus();
 
-    if (!arrays) return span({ class: "outpost-map-units__empty" }, "Map unit arrays are not mapped for this world yet.");
+    if (!arrays)
+        return span({ class: "outpost-map-units__empty" }, "Map unit arrays are not mapped for this world yet.");
 
     return div(
         { class: "outpost-map-unit-add" },
@@ -490,7 +556,9 @@ const UnitSummaryRows = ({ summaries, mapDispNames, mapDetails }) =>
             span({ class: "outpost-vanilla-units__count" }, `${summary.total} Units`),
             span(
                 { class: "outpost-vanilla-units__breakdown" },
-                MAP_UNIT_ORDER.map((unitType) => `${getUnitTypeLabel(unitType)} ${summary.counts[unitType] ?? 0}`).join(" | ")
+                MAP_UNIT_ORDER.map((unitType) => `${getUnitTypeLabel(unitType)} ${summary.counts[unitType] ?? 0}`).join(
+                    " | "
+                )
             ),
             span(
                 { class: "outpost-vanilla-units__meta" },
@@ -530,7 +598,9 @@ const UnitBulkPanel = ({ royalGState, onChanged, outpostsByWorld, mapDispNames, 
             mode: "custom",
             summaries: buildDistributedUnitArrays(royalGState.val ?? [], getWantedCounts(), outpostsByWorld).summaries,
         };
-        summaryList.replaceChildren(...UnitSummaryRows({ summaries: previewState.val.summaries, mapDispNames, mapDetails }));
+        summaryList.replaceChildren(
+            ...UnitSummaryRows({ summaries: previewState.val.summaries, mapDispNames, mapDetails })
+        );
     };
 
     worlds.forEach((world) => {
@@ -565,21 +635,12 @@ const UnitBulkPanel = ({ royalGState, onChanged, outpostsByWorld, mapDispNames, 
                     label: "RESET TO VANILLA",
                     status: vanillaStatus.status,
                     variant: "danger",
-                    tooltip: "Rebuild RoyalG map-unit arrays from current militia and Kingdom Sovereignty upgrade levels.",
+                    tooltip:
+                        "Rebuild RoyalG map-unit arrays from current militia and Kingdom Sovereignty upgrade levels.",
                     onClick: (e) => {
                         e.preventDefault();
                         void vanillaStatus.run(async () => {
-                            const rawRoyalG = await gga("RoyalG");
-                            const royalG = toIndexedArray(rawRoyalG ?? []);
-                            const { rebuilt } = buildVanillaUnitArrays(royalG);
-                            const writes = [];
-
-                            Object.values(rebuilt).forEach((entry) => {
-                                writes.push({ path: `RoyalG[${entry.typeArray}]`, value: entry.types });
-                                writes.push({ path: `RoyalG[${entry.mapArray}]`, value: entry.maps });
-                            });
-
-                            await writeManyVerified(writes);
+                            await rebuildRoyalGuardVanillaUnits();
                             if (typeof onChanged === "function") await onChanged();
                         });
                     },
@@ -624,7 +685,15 @@ const UnitBulkPanel = ({ royalGState, onChanged, outpostsByWorld, mapDispNames, 
     );
 };
 
-const BuiltOutpostRow = ({ outpost, fieldStates, slotState, outpostTypeState, glorifiedState, mapUnits, onUnitsChanged }) => {
+const BuiltOutpostRow = ({
+    outpost,
+    fieldStates,
+    slotState,
+    outpostTypeState,
+    glorifiedState,
+    mapUnits,
+    onUnitsChanged,
+}) => {
     const syncCapacity = async (nextBarracks = fieldStates.get("barracks").val, nextGlorified = glorifiedState.val) => {
         await syncSlotsToCapacity({
             mapId: outpost.mapId,
@@ -761,7 +830,10 @@ const KillOutpostRow = ({ outpost, remainingState, onConverted }) =>
             div(
                 { class: "outpost-row__text" },
                 span({ class: "account-row__name" }, outpost.name),
-                span({ class: "outpost-row__meta" }, `Kills done ${formatAmount(outpost.kills)} / ${formatAmount(outpost.killReq)}`)
+                span(
+                    { class: "outpost-row__meta" },
+                    `Kills done ${formatAmount(outpost.kills)} / ${formatAmount(outpost.killReq)}`
+                )
             ),
         ],
         renderBadge: (remaining) => `LEFT ${formatAmount(remaining)}`,

--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -160,18 +160,15 @@ const decodeSlots = (value) =>
         .slice(-9)
         .split("");
 const encodeSlots = (slots) => Number(slots.join(""));
-const unlockedSlotCount = (barracksLevel, glorified) =>
-    Math.max(
-        0,
-        Math.min(9, 1 + Math.min(5, toInt(barracksLevel, { min: 0, mode: "floor" })) + (toInt(glorified) === 1 ? 1 : 0))
-    );
+const unlockedSlotCount = (barracksLevel) =>
+    Math.max(0, Math.min(6, 1 + Math.min(5, toInt(barracksLevel, { min: 0, mode: "floor" }))));
 
 const outpostTypeLabel = (type) =>
     OUTPOST_TYPES.find((entry) => entry.value === Number(type))?.label ?? `Outpost Type ${type}`;
 
-const normalizeSlotsForCapacity = (slotValue, barracksLevel, glorified) => {
+const normalizeSlotsForCapacity = (slotValue, barracksLevel) => {
     const slots = decodeSlots(slotValue);
-    const unlockedSlots = unlockedSlotCount(barracksLevel, glorified);
+    const unlockedSlots = unlockedSlotCount(barracksLevel);
 
     for (let slot = 0; slot < slots.length; slot++) {
         if (slot >= unlockedSlots) {
@@ -184,12 +181,13 @@ const normalizeSlotsForCapacity = (slotValue, barracksLevel, glorified) => {
     return encodeSlots(slots);
 };
 
-const syncSlotsToCapacity = async ({ mapId, slotState, barracksLevel, glorified }) => {
-    const nextValue = normalizeSlotsForCapacity(slotState.val, barracksLevel, glorified);
+const syncSlotsToCapacity = async ({ mapId, slotState, barracksLevel }) => {
+    const nextValue = normalizeSlotsForCapacity(slotState.val, barracksLevel);
     if (nextValue === slotState.val) return;
 
     await writeVerified(`RoyalMaps[${mapId}][11]`, nextValue);
     slotState.val = nextValue;
+    await refreshRoyalGuardUnitCaches();
 };
 
 const readUnitPair = async (typeArray, mapArray) => {
@@ -325,7 +323,7 @@ export const resetRoyalGuardUnitsToVanilla = async () => {
 
     royalMaps.forEach((row, mapId) => {
         if (!Array.isArray(row) || row.length < BUILT_OUTPOST_LENGTH) return;
-        const nextSlots = normalizeSlotsForCapacity(row[11], row[0], row[12]);
+        const nextSlots = normalizeSlotsForCapacity(row[11], row[0]);
         if (nextSlots !== row[11]) writes.push({ path: `RoyalMaps[${mapId}][11]`, value: nextSlots });
     });
 
@@ -411,10 +409,10 @@ const SelectWriter = ({ label, valueState, options, path, onApplied = null, clas
     );
 };
 
-const OutpostSlots = ({ mapId, slotState, barracksState, glorifiedState }) => {
+const OutpostSlots = ({ mapId, slotState, barracksState }) => {
     const { status, run } = useWriteStatus();
     const slots = () => decodeSlots(slotState.val);
-    const unlockedSlots = () => unlockedSlotCount(barracksState.val, glorifiedState.val);
+    const unlockedSlots = () => unlockedSlotCount(barracksState.val);
 
     return div(
         { class: "outpost-slots" },
@@ -436,6 +434,7 @@ const OutpostSlots = ({ mapId, slotState, barracksState, glorifiedState }) => {
                         void run(async () => {
                             await writeVerified(`RoyalMaps[${mapId}][11]`, nextValue);
                             slotState.val = nextValue;
+                            await refreshRoyalGuardUnitCaches();
                         });
                     },
                 },
@@ -693,12 +692,11 @@ const BuiltOutpostRow = ({
     mapUnits,
     onUnitsChanged,
 }) => {
-    const syncCapacity = async (nextBarracks = fieldStates.get("barracks").val, nextGlorified = glorifiedState.val) => {
+    const syncCapacity = async (nextBarracks = fieldStates.get("barracks").val) => {
         await syncSlotsToCapacity({
             mapId: outpost.mapId,
             slotState,
             barracksLevel: nextBarracks,
-            glorified: nextGlorified,
         });
     };
 
@@ -718,7 +716,12 @@ const BuiltOutpostRow = ({
             label: () => fieldLabel(field),
             valueState: fieldStates.get(field.key),
             path: `RoyalMaps[${outpost.mapId}][${field.index}]`,
-            onApplied: field.key === "barracks" ? (value) => syncCapacity(value, glorifiedState.val) : null,
+            onApplied:
+                field.key === "barracks"
+                    ? (value) => syncCapacity(value)
+                    : field.index === 5
+                      ? () => refreshRoyalGuardUnitCaches()
+                      : null,
             inputMode: field.inputMode,
             normalize: (raw) =>
                 resolveNumberInput(raw, {
@@ -782,7 +785,7 @@ const BuiltOutpostRow = ({
                             await writeVerified(`RoyalMaps[${outpost.mapId}][12]`, nextValue);
                             glorifiedState.val = nextValue;
                             outpost.glorified = nextValue;
-                            await syncCapacity(fieldStates.get("barracks").val, nextValue);
+                            await refreshRoyalGuardUnitCaches();
                         },
                     })
                 )
@@ -801,7 +804,6 @@ const BuiltOutpostRow = ({
                 mapId: outpost.mapId,
                 slotState,
                 barracksState: fieldStates.get("barracks"),
-                glorifiedState,
             }),
             div(
                 { class: "outpost-map-units" },

--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -1,5 +1,9 @@
 import { MasterclassUpgradeTab } from "./MasterclassUpgradeTab.js";
-import { rebuildRoyalGuardVanillaUnits, ROYAL_GUARD_VANILLA_UNIT_UPGRADES } from "./OutpostsTab.js";
+import {
+    MILITIA_SHELF_TO_WORLD,
+    syncRoyalGuardMilitiaForWorld,
+    syncRoyalGuardSovereigntyUnits,
+} from "./OutpostsTab.js";
 
 const resourceFields = (resourceIds) =>
     resourceIds.map((resourceId) => ({
@@ -28,12 +32,18 @@ export const RoyalArmoryTab = () =>
         currencyTitle: "ROYAL RESOURCES",
         currencyTabs: ROYAL_ARMORY_RESOURCE_TABS,
         fallbackPrefix: "Royal Armory Upgrade",
-        onUpgradeChanged: ({ upgrade }) =>
-            ROYAL_GUARD_VANILLA_UNIT_UPGRADES.has(Number(upgrade.storageIndex))
-                ? rebuildRoyalGuardVanillaUnits()
-                : null,
-        onBulkChanged: ({ upgrades }) =>
-            upgrades.some((upgrade) => ROYAL_GUARD_VANILLA_UNIT_UPGRADES.has(Number(upgrade.storageIndex)))
-                ? rebuildRoyalGuardVanillaUnits()
-                : null,
+        onUpgradeChanged: ({ upgrade }) => {
+            const shelf = Number(upgrade.index);
+            if (shelf === 28) return syncRoyalGuardSovereigntyUnits();
+            const world = MILITIA_SHELF_TO_WORLD[shelf];
+            return world ? syncRoyalGuardMilitiaForWorld(world) : null;
+        },
+        onBulkChanged: ({ upgrades }) => {
+            const shelves = new Set(upgrades.map((upgrade) => Number(upgrade.index)));
+            const tasks = Object.entries(MILITIA_SHELF_TO_WORLD)
+                .filter(([shelf]) => shelves.has(Number(shelf)))
+                .map(([, world]) => syncRoyalGuardMilitiaForWorld(world));
+            if (shelves.has(28)) tasks.push(syncRoyalGuardSovereigntyUnits());
+            return Promise.all(tasks);
+        },
     });

--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -1,4 +1,5 @@
 import { MasterclassUpgradeTab } from "./MasterclassUpgradeTab.js";
+import { rebuildRoyalGuardVanillaUnits, ROYAL_GUARD_VANILLA_UNIT_UPGRADES } from "./OutpostsTab.js";
 
 const resourceFields = (resourceIds) =>
     resourceIds.map((resourceId) => ({
@@ -27,4 +28,12 @@ export const RoyalArmoryTab = () =>
         currencyTitle: "ROYAL RESOURCES",
         currencyTabs: ROYAL_ARMORY_RESOURCE_TABS,
         fallbackPrefix: "Royal Armory Upgrade",
+        onUpgradeChanged: ({ upgrade }) =>
+            ROYAL_GUARD_VANILLA_UNIT_UPGRADES.has(Number(upgrade.storageIndex))
+                ? rebuildRoyalGuardVanillaUnits()
+                : null,
+        onBulkChanged: ({ upgrades }) =>
+            upgrades.some((upgrade) => ROYAL_GUARD_VANILLA_UNIT_UPGRADES.has(Number(upgrade.storageIndex)))
+                ? rebuildRoyalGuardVanillaUnits()
+                : null,
     });

--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -1,9 +1,5 @@
 import { MasterclassUpgradeTab } from "./MasterclassUpgradeTab.js";
-import {
-    MILITIA_SHELF_TO_WORLD,
-    syncRoyalGuardMilitiaForWorld,
-    syncRoyalGuardSovereigntyUnits,
-} from "./OutpostsTab.js";
+import { UNIT_REBUILD_SHELVES, resetRoyalGuardUnitsToVanilla } from "./OutpostsTab.js";
 
 const resourceFields = (resourceIds) =>
     resourceIds.map((resourceId) => ({
@@ -32,18 +28,11 @@ export const RoyalArmoryTab = () =>
         currencyTitle: "ROYAL RESOURCES",
         currencyTabs: ROYAL_ARMORY_RESOURCE_TABS,
         fallbackPrefix: "Royal Armory Upgrade",
-        onUpgradeChanged: ({ upgrade }) => {
-            const shelf = Number(upgrade.index);
-            if (shelf === 28) return syncRoyalGuardSovereigntyUnits();
-            const world = MILITIA_SHELF_TO_WORLD[shelf];
-            return world ? syncRoyalGuardMilitiaForWorld(world) : null;
-        },
+        onUpgradeChanged: ({ upgrade }) =>
+            UNIT_REBUILD_SHELVES.has(Number(upgrade.index)) ? resetRoyalGuardUnitsToVanilla() : null,
         onBulkChanged: ({ upgrades }) => {
-            const shelves = new Set(upgrades.map((upgrade) => Number(upgrade.index)));
-            const tasks = Object.entries(MILITIA_SHELF_TO_WORLD)
-                .filter(([shelf]) => shelves.has(Number(shelf)))
-                .map(([, world]) => syncRoyalGuardMilitiaForWorld(world));
-            if (shelves.has(28)) tasks.push(syncRoyalGuardSovereigntyUnits());
-            return Promise.all(tasks);
+            return upgrades.some((upgrade) => UNIT_REBUILD_SHELVES.has(Number(upgrade.index)))
+                ? resetRoyalGuardUnitsToVanilla()
+                : null;
         },
     });

--- a/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
+++ b/src/ui/components/views/account/masterclasses/RoyalArmoryTab.js
@@ -1,5 +1,5 @@
 import { MasterclassUpgradeTab } from "./MasterclassUpgradeTab.js";
-import { UNIT_REBUILD_SHELVES, resetRoyalGuardUnitsToVanilla } from "./OutpostsTab.js";
+import { UNIT_REBUILD_DISPLAY_SHELVES, resetRoyalGuardUnitsToVanilla } from "./OutpostsTab.js";
 
 const resourceFields = (resourceIds) =>
     resourceIds.map((resourceId) => ({
@@ -18,6 +18,8 @@ const ROYAL_ARMORY_RESOURCE_TABS = [
     { id: "w4", label: "W4", fields: resourceFields(range(30, 39)) },
 ];
 
+const getDisplayShelf = (upgrade) => Number(upgrade.index) + 1;
+
 export const RoyalArmoryTab = () =>
     MasterclassUpgradeTab({
         title: "ROYAL ARMORY",
@@ -29,9 +31,9 @@ export const RoyalArmoryTab = () =>
         currencyTabs: ROYAL_ARMORY_RESOURCE_TABS,
         fallbackPrefix: "Royal Armory Upgrade",
         onUpgradeChanged: ({ upgrade }) =>
-            UNIT_REBUILD_SHELVES.has(Number(upgrade.index)) ? resetRoyalGuardUnitsToVanilla() : null,
+            UNIT_REBUILD_DISPLAY_SHELVES.has(getDisplayShelf(upgrade)) ? resetRoyalGuardUnitsToVanilla() : null,
         onBulkChanged: ({ upgrades }) => {
-            return upgrades.some((upgrade) => UNIT_REBUILD_SHELVES.has(Number(upgrade.index)))
+            return upgrades.some((upgrade) => UNIT_REBUILD_DISPLAY_SHELVES.has(getDisplayShelf(upgrade)))
                 ? resetRoyalGuardUnitsToVanilla()
                 : null;
         },


### PR DESCRIPTION
## Summary
- Rebuild vanilla Royal Guard unit arrays when unit-granting Royal Armory shelves change.
- Share the full vanilla reset between Royal Armory and Outposts.
- Preserve paired unit/map alignment, outpost slot capacity, and invalidate unit-total caches.
- Resolve displayed shelf numbers through zero-based Research[43] ordering.

## Validation
- npm run validate