### PR TITLE
Fix fallback outpost kill requirements

### DIFF
--- a/src/ui/components/views/account/masterclasses/OutpostsTab.js
+++ b/src/ui/components/views/account/masterclasses/OutpostsTab.js
@@ -212,7 +212,8 @@ const getKillReq = (mapId, mapDetails, killReqOverrides) => {
     const overrides = unwrapH(killReqOverrides) ?? {};
     if (Object.prototype.hasOwnProperty.call(overrides, String(mapId))) return toNum(overrides[String(mapId)], 0);
 
-    const detail = toIndexedArray(toIndexedArray(mapDetails[mapId] ?? [])[0] ?? []);
+    const mapDetail = toIndexedArray(unwrapH(mapDetails?.[mapId]) ?? []);
+    const detail = toIndexedArray(unwrapH(mapDetail[0]) ?? []);
     return (
         3 *
         (25 +


### PR DESCRIPTION
Unwrap MapDetails entries before computing fallback kill requirements, so maps without RG_KillReq overrides (such as Rats Nest / M15) use their actual requirements.